### PR TITLE
Fix build on x86_gcc2 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ vmware_fs: vmware_fs/objects/vmware_fs
 vmware_mouse: vmware_mouse/objects/vmware_mouse
 	cp $< $@
 
-vmware_video_accelerant: vmware_tray/objects/vmware_video/accelerant
+vmware_video_accelerant: vmware_video/accelerant/objects/vmware.accelerant
 	cp $< "$@"
 
-vmware_video_kernel: vmware_tray/objects/vmware_video/kernel
+vmware_video_kernel: vmware_video/kernel/objects/vmware
+	cp $< "$@"
+	
+vmware_tray: vmware_tray/objects/vmware_tray
 	cp $< "$@"
 
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 # VMware Add-ons
 
-By Vincent Duvert <vincent.duvert@free.fr>
+By Vincent Duvert <vincent.duvert@free.fr>  
 GitHub page: https://github.com/HaikuArchives/VMwareAddons
 
-VMW Add-ons are a set of tools to enhance interaction between Haiku, running in a virtual machine, and the host operating system. It is like the official VMware tools on Windows or Linux.
+VMW Add-ons is a set of tools to enhance interaction between Haiku running in a virtual machine, and the host operating system. 
+It's similar to the official VMware Tools on Windows or Linux.
 
-**It currently provides**:
- - Clipboard sharing between Haiku and the host OS.
+### Features  
+ - Clipboard sharing between Haiku and the host OS. Use the VMware add-ons desktop applet to enable or disable the sharing.
  - Mouse sharing: the mouse can seamlessly enter and leave the VM window.
- - Shared folders: easily share files between Haiku and the host OS.
- - Disk compacting: Starts the VMware "shrink" process, which reduce the size of "auto-expanding" virtual disks attached to the virtual machine. The free space on disks is cleaned up previously, in order to get better results.
- - Graphics driver for VMware: you can choose your preferred resolution using Screen preflet in Haiku.
- - Graphics driver for VirtualBox: change grapchics card in VM settings to VMSVGA and video memory size to 64 MB to get higher resolutions working.
+ - Shared folders: easily share files between Haiku and the host OS. The shared folders can be mounted in Haiku using `mount -t vmwfs ~/shared`.
+ - Disk compacting: starts the VMware "shrink" process, which reduces the size of "auto-expanding" virtual disks attached to the virtual machine. The free space on disks is cleaned up previously, in order to get better results.
+ - Graphics driver for VMware: you can choose your preferred resolution using the Screen preflet in Haiku.
+ - Graphics driver for VirtualBox: change the graphics controller in the VM settings to `VMSVGA`, and set the video memory size to 64 MB to be able to use higher resolutions.
 
-**Known bugs and limitations**:
- - If you have a volume with more than 800GB of free space, not all free space will be cleaned up on this volume — only 800GB — before the shrink process.
- - When mouse sharing is activated, the cursor speed and acceleration are given by the host operating system (setting them in the "Mouse" control panel will have no effect).
+### Known bugs and limitations  
+ - If you have a volume with more than 800GB of free space, not all free space will be cleaned up on the volume before the shrink process — just 800GB.
+ - When mouse sharing is activated, the cursor speed and acceleration are defined by the host operating system (setting them in the "Mouse" control panel will have no effect).
 
 If you encounter a bug or have a feature request, please use the tracker at:
 https://github.com/HaikuArchives/VMwareAddons/issues
 
-**Planned features**:
+### Planned features
  - Virtual machine window resizing

--- a/enhanced_backdoor/Makefile
+++ b/enhanced_backdoor/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 CXX=g++
-CFLAGS=-I. -g -W -Wall -Wno-multichar -ansi -pedantic -Werror
+CFLAGS=-I. -g -W -Wall -Wno-multichar -ansi -pedantic
 LDFLAGS=-lbe 
 
 all: run_backdoor

--- a/vmware_fs/Makefile
+++ b/vmware_fs/Makefile
@@ -55,7 +55,10 @@ RSRCS=
 #		and it's name
 #		library: my_lib.a entry: my_lib.a or path/my_lib.a
 #  ---
+#
 #  Haiku drivers cannot depend on libstdc++.a, we use libsupc++-kernel.a instead.
+#  For gcc2 we link just libgcc.a, as there's no libsupc++-kernel.a
+#
 #  As stated by https://gcc.gnu.org/onlinedocs/libstdc++/faq.html#faq.what_is_libsupcxx
 #    If the only functions from libstdc++.a which you need are language support functions
 #    (those listed in clause 18 of the standard, e.g., new and delete),
@@ -64,7 +67,7 @@ RSRCS=
 #    link step will do it). This library contains only those support routines, one per object file.
 #    But if you are using anything from the rest of the library, such as IOStreams or vectors,
 #    then you'll still need pieces from libstdc++.a
-LIBS= gcc-kernel supc++-kernel
+LIBS= $(if $(filter $(CC_VER), 2), gcc, gcc-kernel supc++-kernel)
 
 #	specify additional paths to directories following the standard
 #	libXXX.so or libXXX.a naming scheme. You can specify full paths
@@ -112,7 +115,7 @@ SYMBOLS = TRUE
 DEBUGGER =
 
 #	specify additional compiler flags for all files
-COMPILER_FLAGS = -Werror -Wall -Wconversion
+COMPILER_FLAGS = -Werror -Wall -Wconversion -Wno-multichar
 
 #	specify additional linker flags
 LINKER_FLAGS = 

--- a/vmware_tray/VMWAddOnsTray.cpp
+++ b/vmware_tray/VMWAddOnsTray.cpp
@@ -360,7 +360,7 @@ VMWAddOnsMenu::VMWAddOnsMenu(VMWAddOnsTray* tray, bool in_vmware)
 
 	AddSeparatorItem();
 
-	AddItem(new BMenuItem("About "APP_NAME B_UTF8_ELLIPSIS, new BMessage(B_ABOUT_REQUESTED)));
+	AddItem(new BMenuItem("About " APP_NAME B_UTF8_ELLIPSIS, new BMessage(B_ABOUT_REQUESTED)));
 	AddItem(new BMenuItem("Quit" B_UTF8_ELLIPSIS, new BMessage(REMOVE_FROM_DESKBAR)));
 
 	SetTargetForItems(tray);

--- a/vmware_video/kernel/device.c
+++ b/vmware_video/kernel/device.c
@@ -332,10 +332,10 @@ ControlHook(void *dev, uint32 msg, void *buf, size_t len)
 		case VMWARE_SET_PALETTE:
 		{
 			uint8 colors[3 * 256];
-			if (user_memcpy(colors, buf, sizeof(colors)) < B_OK)
-				return B_BAD_ADDRESS;
 			uint8 *color = colors;
 			uint32 i;
+			if (user_memcpy(colors, buf, sizeof(colors)) < B_OK)
+				return B_BAD_ADDRESS;
 			if (ReadReg(SVGA_REG_PSEUDOCOLOR) != 1)
 				return B_ERROR;
 


### PR DESCRIPTION
- Fixes the `x86_gcc2` build
- Fixes the `-Wliteral-suffix` warning for the gcc8 `x86_64` build 
- Fixes wrong paths in the root `Makefile`
- Updates the README file