### PR TITLE
Completed support for "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,14 @@ clean:
 	make -C vmware_video/accelerant clean
 	make -C vmware_video/kernel clean
 
+install: build
+	make -C vmware_fs install
+	make -C vmware_mouse install
+	make -C enhanced_backdoor install
+	make -C vmware_tray install
+	make -C vmware_video/accelerant install
+	make -C vmware_video/kernel install
+	mkdir -p "$(HOME)/config/settings/deskbar/menu/Desktop applets"
+	ln -sf /boot/system/non-packaged/bin/vmware_tray "$(HOME)/config/settings/deskbar/menu/Desktop applets/VMware add-ons"
 
 .PHONY: build release clean

--- a/enhanced_backdoor/Makefile
+++ b/enhanced_backdoor/Makefile
@@ -1,21 +1,136 @@
-CC=gcc
-CXX=g++
-CFLAGS=-I. -g -W -Wall -Wno-multichar -ansi -pedantic
-LDFLAGS=-lbe 
+## BeOS Generic Makefile v2.2 ##
 
-all: run_backdoor
+## Fill in this file to specify the project being created, and the referenced
+## makefile-engine will do all of the hard work for you. This handles both
+## Intel and PowerPC builds of the BeOS and Haiku.
 
-run_backdoor: main.o VMWBackdoor.o
-	$(CXX) -o "$@" $^ $(LDFLAGS)
-	mimeset "$@"
+## Application Specific Settings ---------------------------------------------
 
-%.o: %.cpp
-	$(CXX) -o $@ -c $< $(CFLAGS)
+# specify the name of the binary
+NAME= run_backdoor
 
-clean:
-	rm -rf *.o
+# specify the type of binary
+#	APP:	Application
+#	SHARED:	Shared library or add-on
+#	STATIC:	Static library archive
+#	DRIVER: Kernel Driver
+TYPE= APP
 
-mrproper: clean
-	rm -f run_backdoor
+#	add support for new Pe and Eddie features
+#	to fill in generic makefile
 
-.PHONY: clean mrproper
+#%{
+# @src->@ 
+
+#	specify the source files to use
+#	full paths or paths relative to the makefile can be included
+# 	all files, regardless of directory, will have their object
+#	files created in the common object directory.
+#	Note that this means this makefile will not work correctly
+#	if two source files with the same name (source.c or source.cpp)
+#	are included from different directories. Also note that spaces
+#	in folder names do not work well with this makefile.
+SRCS= main.cpp VMWBackdoor.cpp
+
+#	specify the resource definition files to use
+#	full path or a relative path to the resource file can be used.
+RDEFS= 
+	
+#	specify the resource files to use. 
+#	full path or a relative path to the resource file can be used.
+#	both RDEFS and RSRCS can be defined in the same makefile.
+RSRCS= 
+
+# @<-src@ 
+#%}
+
+#	end support for Pe and Eddie
+
+#	specify additional libraries to link against
+#	there are two acceptable forms of library specifications
+#	-	if your library follows the naming pattern of:
+#		libXXX.so or libXXX.a you can simply specify XXX
+#		library: libbe.so entry: be
+#		
+#	- 	if your library does not follow the standard library
+#		naming scheme you need to specify the path to the library
+#		and it's name
+#		library: my_lib.a entry: my_lib.a or path/my_lib.a
+LIBS= be $(STDCPPLIBS)
+
+#	specify additional paths to directories following the standard
+#	libXXX.so or libXXX.a naming scheme. You can specify full paths
+#	or paths relative to the makefile. The paths included may not
+#	be recursive, so include all of the paths where libraries can
+#	be found. Directories where source files are found are
+#	automatically included.
+LIBPATHS= 
+
+#	additional paths to look for system headers
+#	thes use the form: #include <header>
+#	source file directories are NOT auto-included here
+SYSTEM_INCLUDE_PATHS = 
+
+#	additional paths to look for local headers
+#	thes use the form: #include "header"
+#	source file directories are automatically included
+LOCAL_INCLUDE_PATHS = 
+
+#	specify the level of optimization that you desire
+#	NONE, SOME, FULL
+OPTIMIZE= SOME
+
+#	specify any preprocessor symbols to be defined. The symbols will not
+#	have their values set automatically; you must supply the value (if any)
+#	to use. For example, setting DEFINES to "DEBUG=1" will cause the
+#	compiler option "-DDEBUG=1" to be used. Setting DEFINES to "DEBUG"
+#	would pass "-DDEBUG" on the compiler's command line.
+DEFINES= 
+
+#	specify special warning levels
+#	if unspecified default warnings will be used
+#	NONE = supress all warnings
+#	ALL = enable all warnings
+WARNINGS = ALL
+
+#	specify whether image symbols will be created
+#	so that stack crawls in the debugger are meaningful
+#	if TRUE symbols will be created
+SYMBOLS = TRUE
+
+#	specify debug settings
+#	if TRUE will allow application to be run from a source-level
+#	debugger. Note that this will disable all optimzation.
+#DEBUGGER = TRUE
+
+ifeq ($(RELEASE),1)
+	OPTIMIZE= FULL
+	DEFINES= PERSISTENT_TRAY
+	SYMBOLS= FALSE
+	DEBUGGER= FALSE
+endif
+
+#	specify additional compiler flags for all files
+COMPILER_FLAGS =
+
+#	specify additional linker flags
+LINKER_FLAGS = 
+
+INSTALL_DIR = /boot/system/non-packaged/bin
+
+#	specify the version of this particular item
+#	(for example, -app 3 4 0 d 0 -short 340 -long "340 "`echo -n -e '\302\251'`"1999 GNU GPL") 
+#	This may also be specified in a resource.
+APP_VERSION = 
+
+#	(for TYPE == DRIVER only) Specify desired location of driver in the /dev
+#	hierarchy. Used by the driverinstall rule. E.g., DRIVER_PATH = video/usb will
+#	instruct the driverinstall rule to place a symlink to your driver's binary in
+#	~/add-ons/kernel/drivers/dev/video/usb, so that your driver will appear at
+#	/dev/video/usb when loaded. Default is "misc".
+DRIVER_PATH = 
+
+## include the makefile-engine
+DEVEL_DIRECTORY := \
+	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
+include $(DEVEL_DIRECTORY)/etc/makefile-engine

--- a/vmware_tray/Makefile
+++ b/vmware_tray/Makefile
@@ -118,6 +118,8 @@ COMPILER_FLAGS =
 #	specify additional linker flags
 LINKER_FLAGS = 
 
+INSTALL_DIR = /boot/system/non-packaged/bin
+
 #	specify the version of this particular item
 #	(for example, -app 3 4 0 d 0 -short 340 -long "340 "`echo -n -e '\302\251'`"1999 GNU GPL") 
 #	This may also be specified in a resource.


### PR DESCRIPTION
"make install" in the root now installs everything into the non-packaged directory, which makes development and testing easier. This support was 80% implemented already, just finished support in a couple subdirs and added it to the root Makefile.

The Haiku makefile-engine was being used by all Makefiles except enhanced_backdoor, so that was also updated to use the makefile-engine which enables "install" support for that one as well.