### PR TITLE
Host clock sync: minor fixes for non-ancient VMware WS versions.

### DIFF
--- a/shared_sources/VMWBackdoor.h
+++ b/shared_sources/VMWBackdoor.h
@@ -21,7 +21,7 @@ public:
 	void		GetCursorStatus(uint16& status, uint16& to_read);
 	status_t	GetHostClipboard(char** text, size_t *text_length);
 	status_t	SetHostClipboard(char* text, size_t length);
-	int32		GetHostClock();
+	ulong		GetHostClock();
 };
 
 #endif

--- a/vmware_tray/VMWAddOnsTray.cpp
+++ b/vmware_tray/VMWAddOnsTray.cpp
@@ -22,7 +22,7 @@
 VMWAddOnsSettings settings;
 
 #define CLIP_POLL_DELAY 1000000
-#define CLOCK_POLL_DELAY 30000000
+#define CLOCK_POLL_DELAY 60000000
 
 extern "C" _EXPORT BView* instantiate_deskbar_item(float /*maxWidth*/, float maxHeight)
 {
@@ -219,7 +219,7 @@ VMWAddOnsTray::MessageReceived(BMessage* message)
 
 		case CLOCK_POLL:
 		{
-			int32 clock_value = backdoor.GetHostClock();
+			ulong clock_value = backdoor.GetHostClock();
 			if (clock_value > 0)
 				set_real_time_clock(clock_value);
 		}


### PR DESCRIPTION
- All involved data types are ulong, not int32.
- VMW_BACK_GET_HOST_TIME doesn't returns timezone offset anymore.
- Reduce polling interval to once per minute (same value used by default on the official "open_vmware_tools").

Note: "VMW_BACK_GET_HOST_TIME" (=23) is deprecated.

We should switch to using the suggested "*_GETTIMEFULL" (=46) command instead.