### PR TITLE
vmware_tray: add a time sync option, obey VMware settings.

### DIFF
--- a/shared_sources/VMWBackdoor.cpp
+++ b/shared_sources/VMWBackdoor.cpp
@@ -178,6 +178,39 @@ VMWBackdoor::SetHostClipboard(char* text, size_t text_length)
 }
 
 
+bool
+VMWBackdoor::GetGUISetting(gui_setting setting)
+{
+	if (!InVMware())
+		return 0;
+
+	regs_t regs;
+	BackdoorCall(&regs, VMW_BACK_GET_GUI_SETTING);
+	return (regs.eax & setting) != 0;
+}
+
+/*
+void
+VMWBackdoor::SetGUISetting(gui_setting setting, bool enabled)
+{
+	if (!InVMware())
+		return;
+
+	regs_t regs;
+	// Get current settings:
+	BackdoorCall(&regs, VMW_BACK_GET_GUI_SETTING);
+	ulong settings = regs.eax;
+
+	// Set the one requested:
+	if (enabled)
+		settings |= setting;
+	else
+		settings &= (settings ^ setting);
+
+	BackdoorCall(&regs, VMW_BACK_SET_GUI_SETTING, setting);
+}
+*/
+
 ulong
 VMWBackdoor::GetHostClock()
 {

--- a/shared_sources/VMWBackdoor.h
+++ b/shared_sources/VMWBackdoor.h
@@ -12,6 +12,16 @@
 
 class VMWBackdoor : public VMWCoreBackdoor {
 public:
+	// Only listing values still seen on VMware WS 17.x
+	enum gui_setting {
+		POINTER_GRAB_UNGRAB	= 0x0003,	// Grab (0x1)/Ungrab(0x2) are combined on newer versions.
+										// VMware-wide preference.
+		CLIP_BOARD_SHARING	= 0x0010,	// per-VM setting.
+		UNKOWN_SETTING_1	= 0x0200,
+		TIME_SYNC			= 0x0400,	// per-VM setting. Only one still used on open_vmware_tools code.
+		UNKOWN_SETTING_2	= 0x0800,
+	};
+
 				VMWBackdoor();
 	virtual		~VMWBackdoor();
 
@@ -21,6 +31,8 @@ public:
 	void		GetCursorStatus(uint16& status, uint16& to_read);
 	status_t	GetHostClipboard(char** text, size_t *text_length);
 	status_t	SetHostClipboard(char* text, size_t length);
+	bool		GetGUISetting(gui_setting setting);
+	// void		SetGUISetting(gui_setting setting, bool enabled);
 	ulong		GetHostClock();
 };
 

--- a/shared_sources/VMWCoreBackdoor.h
+++ b/shared_sources/VMWCoreBackdoor.h
@@ -10,13 +10,11 @@
 
 #include <Message.h>
 
-#define VMW_BACK_MAGIC				0x564D5868UL
 // https://web.archive.org/web/20100610223425/http://chitchat.at.infoseek.co.jp/vmware/backdoor.html
+#define VMW_BACK_MAGIC				0x564D5868UL
 #define VMW_BACK_PORT				0x00005658UL
 
 #define VMWARE_ERROR				0xFFFF
-
-#define VMW_BACK_GET_VERSION		0x0A
 
 #define VMW_BACK_RPC_MAGIC			0x49435052UL
 #define VMW_BACK_RPC_PORT			0x5658
@@ -29,11 +27,15 @@
 #define VMW_BACK_RPC_OK				0x00010000UL
 #define VMW_BACK_RPC_SEND_L_OK		0x00810000UL
 #define VMW_BACK_RPC_GET_L_OK		0x00830000UL
+
 #define VMW_BACK_GET_CURSOR 		0x04
 #define VMW_BACK_GET_CLIP_LENGTH	0x06
 #define VMW_BACK_GET_CLIP_DATA		0x07
 #define VMW_BACK_SET_CLIP_LENGTH	0x08
 #define VMW_BACK_SET_CLIP_DATA		0x09
+#define VMW_BACK_GET_VERSION		0x0A
+#define VMW_BACK_GET_GUI_SETTING	0x0D
+#define VMW_BACK_SET_GUI_SETTING	0x0E
 #define VMW_BACK_GET_HOST_TIME		0x17
 #define VMW_BACK_MOUSE_DATA			0x27
 #define VMW_BACK_MOUSE_STATUS		0x28

--- a/vmware_tray/VMWAddOns.h
+++ b/vmware_tray/VMWAddOns.h
@@ -16,6 +16,7 @@
 #define RELOAD_SETTINGS 'reSg'
 #define MOUSE_SHARING 'moSh'
 #define CLIPBOARD_SHARING 'clSh'
+#define TIMESYNC_HOST 'TsyH'
 #define REMOVE_FROM_DESKBAR 'rmDe'
 #define CLIPBOARD_POLL 'clPo'
 #define CLOCK_POLL 'ckPo'

--- a/vmware_tray/VMWAddOnsTray.h
+++ b/vmware_tray/VMWAddOnsTray.h
@@ -36,6 +36,7 @@ private:
 	void					init();
 	void					RemoveMyself(bool askUser);
 	void					SetClipboardSharing(bool enable);
+	void					SetTimeSynchronization(bool enable);
 
 	BBitmap*				icon_all;
 	BBitmap*				icon_mouse;
@@ -52,7 +53,7 @@ private:
 
 class VMWAddOnsMenu: public BPopUpMenu {
 public:
-					VMWAddOnsMenu(VMWAddOnsTray* tray, bool in_vmware);
+					VMWAddOnsMenu(VMWAddOnsTray* tray, VMWBackdoor& backdoor);
 	virtual			~VMWAddOnsMenu();
 };
 


### PR DESCRIPTION
This also adds a GetGuiSetting() method to VMWBackdoor, and uses it to only enable mouse/clipboard sharing, and time sync with host, if those settings are actually enabled on VMware.

Also added a SetGuiSetting(), but left it commented out, as I ended up not making use of it.