### PR TITLE
vmware_mouse: code and style cleanups.

### DIFF
--- a/vmware_mouse/VMWareMouse.h
+++ b/vmware_mouse/VMWareMouse.h
@@ -32,7 +32,7 @@ public:
 
 private:
 		void					_ScalePosition(int32& x, int32& y);
-		VMWareSettingsWatcher*	settings_watcher;
+		VMWareSettingsWatcher*	fSettingsWatcher;
 };
 
 #endif // VMWARE_MOUSE_H


### PR DESCRIPTION
* Improved naming of member and global variables.
* Simplified logic on Filter() a bit: GetCursorPosition() already checks the results of GetCursorStatus(), so we use that now. Commented why/when we can get mouse events, with GetCursorPosition() returning no data, adjusted/simplified logic accordingly. This seems to rid of "missing clicks", as reported in PR #45.

----

With the older `vmwmouse` already removed, if this gets merged, we should close #45 as superseded, IMO.