### PR TITLE
shared_sources: code and style cleanups. No functional change intended.

### DIFF
--- a/shared_sources/VMWAddOnsSettings.cpp
+++ b/shared_sources/VMWAddOnsSettings.cpp
@@ -1,72 +1,68 @@
 /*
-	Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
-	All rights reserved. Distributed under the terms of the MIT License.
-*/
+ * Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
 
 #include "VMWAddOnsSettings.h"
 
 #include <FindDirectory.h>
 #include <Path.h>
 
+
 VMWAddOnsSettings::VMWAddOnsSettings()
 {
 	Reload();
 }
 
+
 VMWAddOnsSettings::VMWAddOnsSettings(node_ref* nref)
 {
 	Reload();
-	settings_file.GetNodeRef(nref);
+	fSettingsFile.GetNodeRef(nref);
 }
 
-VMWAddOnsSettings::~VMWAddOnsSettings()
-{
-}
 
 status_t
 VMWAddOnsSettings::OpenSettings()
 {
-	BPath settings_path;
+	BPath settingsPath;
 
-	find_directory(B_USER_SETTINGS_DIRECTORY, &settings_path);
-	settings_path.Append(SETTINGS_FILE_NAME);
+	find_directory(B_USER_SETTINGS_DIRECTORY, &settingsPath);
+	settingsPath.Append(SETTINGS_FILE_NAME);
 
-	settings_file.SetTo(settings_path.Path(), B_READ_WRITE | B_CREATE_FILE);
+	fSettingsFile.SetTo(settingsPath.Path(), B_READ_WRITE | B_CREATE_FILE);
 
-	return settings_file.InitCheck();
+	return fSettingsFile.InitCheck();
 }
+
 
 void
 VMWAddOnsSettings::Reload()
 {
-	if (OpenSettings() == B_OK) {
-		settings_msg.Unflatten(&settings_file);
-	}
+	if (OpenSettings() == B_OK)
+		fSettingsMsg.Unflatten(&fSettingsFile);
 }
+
 
 bool
-VMWAddOnsSettings::GetBool(const char* name, bool default_value)
+VMWAddOnsSettings::GetBool(const char* name, bool defaultValue)
 {
 	bool value;
-	if (settings_msg.FindBool(name, &value) == B_OK) {
+	if (fSettingsMsg.FindBool(name, &value) == B_OK)
 		return value;
-	}
 
-	return default_value;
+	return defaultValue;
 }
+
 
 void
 VMWAddOnsSettings::SetBool(const char* name, bool value)
 {
-	if (settings_msg.ReplaceBool(name, value) == B_NAME_NOT_FOUND) {
-		settings_msg.AddBool(name, value);
-	}
+	if (fSettingsMsg.ReplaceBool(name, value) == B_NAME_NOT_FOUND)
+		fSettingsMsg.AddBool(name, value);
 
-	if (OpenSettings() == B_OK) {
-		settings_msg.Flatten(&settings_file);
-	}
+	if (OpenSettings() == B_OK)
+		fSettingsMsg.Flatten(&fSettingsFile);
 
-	settings_file.Unset();
+	fSettingsFile.Unset();
 }
-
-

--- a/shared_sources/VMWAddOnsSettings.h
+++ b/shared_sources/VMWAddOnsSettings.h
@@ -1,33 +1,33 @@
 /*
-	Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
-	All rights reserved. Distributed under the terms of the MIT License.
-*/
-
+ * Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
 
 #ifndef VMW_SETTINGS_H
 #define VMW_SETTINGS_H
 
 #include <File.h>
 #include <Message.h>
-#include <SupportDefs.h>
+
 
 #define SETTINGS_FILE_NAME "VinDuv.VMWAddOns_settings"
+
 
 class VMWAddOnsSettings {
 public:
 				VMWAddOnsSettings();
 				VMWAddOnsSettings(node_ref* ref);
-	virtual		~VMWAddOnsSettings();
 
 	void		Reload();
-	bool		GetBool(const char* name, bool default_value);
+
+	bool		GetBool(const char* name, bool defaultValue);
 	void		SetBool(const char* name, bool value);
 
 private:
-	BFile		settings_file;
-	BMessage	settings_msg;
-
 	status_t	OpenSettings();
+
+	BFile		fSettingsFile;
+	BMessage	fSettingsMsg;
 };
 
 #endif

--- a/shared_sources/VMWBackdoor.cpp
+++ b/shared_sources/VMWBackdoor.cpp
@@ -1,68 +1,63 @@
 /*
-	Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
-	Copyright 2010-2011 Joshua Stein <jcs@jcs.org>
-	Copyright 2018 Gerasim Troeglazov <3dEyes@gmail.com>
-	All rights reserved. Distributed under the terms of the MIT License.
-*/
+ * Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
+ * Copyright 2010-2011 Joshua Stein <jcs@jcs.org>
+ * Copyright 2018 Gerasim Troeglazov <3dEyes@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
 
 #include "VMWBackdoor.h"
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 
-VMWBackdoor::VMWBackdoor()
-{
-}
-
-VMWBackdoor::~VMWBackdoor()
-{
-}
-
 status_t
 VMWBackdoor::EnableMouseSharing()
 {
-	if (!InVMware()) return B_NOT_ALLOWED;
-	
+	if (!InVMware())
+		return B_NOT_ALLOWED;
+
 	regs_t regs;
 	BackdoorCall(&regs, VMW_BACK_MOUSE_COMMAND, VMW_BACK_MOUSE_READ);
-	
+
 	// Check the status
-	BackdoorCall(&regs, VMW_BACK_MOUSE_STATUS, 0);
+	BackdoorCall(&regs, VMW_BACK_MOUSE_STATUS);
 	int16 status = HIGH_BITS(regs.eax);
 
 	if (status != 1)
 		return B_ERROR;
-	
+
 	// Check VMware's mouse driver version
 	BackdoorCall(&regs, VMW_BACK_MOUSE_DATA, 1);
 	if (regs.eax != VMW_BACK_MOUSE_VERSION)
 		return B_UNSUPPORTED;
-	
+
 	// We want absolute coordinates
 	BackdoorCall(&regs, VMW_BACK_MOUSE_COMMAND, VMW_BACK_MOUSE_REQ_ABSOLUTE);
 
 	return B_OK;
 }
 
+
 status_t
 VMWBackdoor::DisableMouseSharing()
 {
-	if (!InVMware()) return B_NOT_ALLOWED;
-	
+	if (!InVMware())
+		return B_NOT_ALLOWED;
+
 	regs_t regs;
 	BackdoorCall(&regs, VMW_BACK_MOUSE_COMMAND, VMW_BACK_MOUSE_DISABLE);
-	
+
 	// Check the status
-	BackdoorCall(&regs, VMW_BACK_MOUSE_STATUS, 0);
+	BackdoorCall(&regs, VMW_BACK_MOUSE_STATUS);
 	int16 status = HIGH_BITS(regs.eax);
 
 	if (status != -1)
 		return B_ERROR;
-	
+
 	return B_OK;
 }
+
 
 status_t
 VMWBackdoor::GetCursorPosition(int32& x, int32& y)
@@ -71,14 +66,14 @@ VMWBackdoor::GetCursorPosition(int32& x, int32& y)
 		return B_NOT_ALLOWED;
 
 	uint16 status;
-	uint16 to_read;
+	uint16 toRead;
 
-	GetCursorStatus(status, to_read);
+	GetCursorStatus(status, toRead);
 
 	if (status == VMWARE_ERROR)
 		return B_ERROR;
 
-	if (to_read == 0)
+	if (toRead == 0)
 		return B_INTERRUPTED;
 
 	regs_t regs;
@@ -91,17 +86,17 @@ VMWBackdoor::GetCursorPosition(int32& x, int32& y)
 
 
 void
-VMWBackdoor::GetCursorStatus(uint16& status, uint16& to_read)
+VMWBackdoor::GetCursorStatus(uint16& status, uint16& toRead)
 {
 	regs_t regs;
-	BackdoorCall(&regs, VMW_BACK_MOUSE_STATUS, 0);
+	BackdoorCall(&regs, VMW_BACK_MOUSE_STATUS);
 	status = HIGH_BITS(regs.eax);
-	to_read = LOW_BITS(regs.eax);
+	toRead = LOW_BITS(regs.eax);
 }
 
 
 status_t
-VMWBackdoor::GetHostClipboard(char** text, size_t* text_length)
+VMWBackdoor::GetHostClipboard(char** text, size_t* length)
 {
 	if (!InVMware())
 		return B_NOT_ALLOWED;
@@ -110,7 +105,7 @@ VMWBackdoor::GetHostClipboard(char** text, size_t* text_length)
 		return B_ERROR;
 
 	regs_t regs;
-	BackdoorCall(&regs, VMW_BACK_GET_CLIP_LENGTH, 0);
+	BackdoorCall(&regs, VMW_BACK_GET_CLIP_LENGTH);
 
 	uint32_t total, left;
 	total = left = regs.eax;
@@ -129,33 +124,35 @@ VMWBackdoor::GetHostClipboard(char** text, size_t* text_length)
 
 	for (;;) {
 		regs_t regs;
-		BackdoorCall(&regs, VMW_BACK_GET_CLIP_DATA, 0);
+		BackdoorCall(&regs, VMW_BACK_GET_CLIP_DATA);
 
 		memcpy(buffer + (total - left), &regs.eax, left > 4 ? 4 : left);
 
 		if (left <= 4) {
 			buffer[total] = '\0';
 			break;
-		} else
+		} else {
 			left -= 4;
+		}
 	}
 
 	*text = buffer;
-	*text_length = strlen(buffer);
+	*length = strlen(buffer);
 
 	return B_OK;
 }
 
+
 status_t
-VMWBackdoor::SetHostClipboard(char* text, size_t text_length)
+VMWBackdoor::SetHostClipboard(char* text, size_t length)
 {
 	if (!InVMware())
 		return B_NOT_ALLOWED;
 
-	if (text == NULL || text_length == 0)
+	if (text == NULL || length == 0)
 		return B_ERROR;
 
-	text[text_length] = '\0';
+	text[length] = '\0';
 
 	uint32_t total, left;
 	total = left = strlen(text);
@@ -189,7 +186,8 @@ VMWBackdoor::GetGUISetting(gui_setting setting)
 	return (regs.eax & setting) != 0;
 }
 
-/*
+
+#ifdef SET_GUI_SETTINGS
 void
 VMWBackdoor::SetGUISetting(gui_setting setting, bool enabled)
 {
@@ -209,7 +207,8 @@ VMWBackdoor::SetGUISetting(gui_setting setting, bool enabled)
 
 	BackdoorCall(&regs, VMW_BACK_SET_GUI_SETTING, setting);
 }
-*/
+#endif // SET_GUI_SETTINGS
+
 
 ulong
 VMWBackdoor::GetHostClock()
@@ -225,7 +224,7 @@ VMWBackdoor::GetHostClock()
 		return 0;
 
 	// EAX contains the GMT (in seconds since 1/1/1970)
-	// On WS4.0/GSX2.5 and earlier EDX contained the timezone offset (in minutes),
+	// On WS4.0/GSX2.5, and earlier, EDX contained the timezone offset (in minutes),
 	// but returns 0 on WS4.5/GSX3.2 and later.
 	return regs.eax;
 }

--- a/shared_sources/VMWBackdoor.h
+++ b/shared_sources/VMWBackdoor.h
@@ -1,9 +1,9 @@
 /*
-	Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
-	Copyright 2010-2011 Joshua Stein <jcs@jcs.org>
-	Copyright 2018 Gerasim Troeglazov <3dEyes@gmail.com>
-	All rights reserved. Distributed under the terms of the MIT License.
-*/
+ * Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
+ * Copyright 2010-2011 Joshua Stein <jcs@jcs.org>
+ * Copyright 2018 Gerasim Troeglazov <3dEyes@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
 
 #ifndef VMW_BACK_H
 #define VMW_BACK_H
@@ -22,17 +22,20 @@ public:
 		UNKOWN_SETTING_2	= 0x0800,
 	};
 
-				VMWBackdoor();
-	virtual		~VMWBackdoor();
-
 	status_t	EnableMouseSharing();
 	status_t	DisableMouseSharing();
+
 	status_t	GetCursorPosition(int32& x, int32& y);
-	void		GetCursorStatus(uint16& status, uint16& to_read);
-	status_t	GetHostClipboard(char** text, size_t *text_length);
+	void		GetCursorStatus(uint16& status, uint16& toRead);
+
+	status_t	GetHostClipboard(char** text, size_t* length);
 	status_t	SetHostClipboard(char* text, size_t length);
+
 	bool		GetGUISetting(gui_setting setting);
-	// void		SetGUISetting(gui_setting setting, bool enabled);
+#ifdef SET_GUI_SETTINGS
+	void		SetGUISetting(gui_setting setting, bool enabled);
+#endif
+
 	ulong		GetHostClock();
 };
 

--- a/shared_sources/VMWCoreBackdoor.h
+++ b/shared_sources/VMWCoreBackdoor.h
@@ -1,14 +1,15 @@
 /*
-	Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
-	Copyright 2010-2011 Joshua Stein <jcs@jcs.org>
-	Copyright 2018 Gerasim Troeglazov <3dEyes@gmail.com>
-	All rights reserved. Distributed under the terms of the MIT License.
-*/
+ * Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
+ * Copyright 2010-2011 Joshua Stein <jcs@jcs.org>
+ * Copyright 2018 Gerasim Troeglazov <3dEyes@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
 
 #ifndef VMW_BACK_CORE_H
 #define VMW_BACK_CORE_H
 
-#include <Message.h>
+#include <OS.h>
+#include <SupportDefs.h>
 
 // https://web.archive.org/web/20100610223425/http://chitchat.at.infoseek.co.jp/vmware/backdoor.html
 #define VMW_BACK_MAGIC				0x564D5868UL
@@ -37,12 +38,13 @@
 #define VMW_BACK_GET_GUI_SETTING	0x0D
 #define VMW_BACK_SET_GUI_SETTING	0x0E
 #define VMW_BACK_GET_HOST_TIME		0x17
+// Absolute pointer commands
 #define VMW_BACK_MOUSE_DATA			0x27
 #define VMW_BACK_MOUSE_STATUS		0x28
 #define VMW_BACK_MOUSE_COMMAND		0x29
 
-// Mouse sharing commands
 #define VMW_BACK_MOUSE_VERSION		0x3442554a
+// Sub-commmands to VMW_BACK_MOUSE_COMMAND
 #define VMW_BACK_MOUSE_DISABLE		0x000000f5
 #define VMW_BACK_MOUSE_READ			0x45414552
 #define VMW_BACK_MOUSE_REQ_ABSOLUTE	0x53424152
@@ -52,6 +54,7 @@
 #define LOW_BITS(x) ((x) & 0xFFFF)
 #define TO_HIGH(x) ((x) << 16)
 
+
 typedef struct regs_t {
 	ulong eax;
 	ulong ebx;
@@ -60,6 +63,7 @@ typedef struct regs_t {
 	ulong esi;
 	ulong edi;
 } regs_t;
+
 
 class VMWCoreBackdoor {
 public:
@@ -81,14 +85,14 @@ private:
 	void		BackdoorRPCSend(regs_t* regs, char* data, size_t length);
 	void		BackdoorRPCGet(regs_t* regs, char* data, size_t length);
 
-	bool		in_vmware;
+	bool		fInVMWare;
 
-	bool		rpc_opened;
-	ulong		rpc_channel;
-	ulong		rpc_cookie1;
-	ulong		rpc_cookie2;
+	bool		fRPCOpened;
+	ulong		fRPCChannel;
+	ulong		fRPCCookie1;
+	ulong		fRPCCookie2;
 
-	sem_id		backdoor_access;
+	sem_id		fBackdoorAccess;
 };
 
 #endif


### PR DESCRIPTION
* Selectively applied haiku-format to the .cpp files. Left out the methods containing assembly, as-is, as haiku-format was making them look a bit worse, IMO. Left out the header files, for the same reason.
* Manually updated style to match Haiku Coding Guidelines.
* Removed default constructors/destructors.
* Removed unused includes.
* Used "fMemberName" naming style for class member variables.
* Other minor clean ups, here and there.