### PR TITLE
shared_sources: Remove unused GUI settings values.

### DIFF
--- a/shared_sources/VMWBackdoor.h
+++ b/shared_sources/VMWBackdoor.h
@@ -12,14 +12,12 @@
 
 class VMWBackdoor : public VMWCoreBackdoor {
 public:
-	// Only listing values still seen on VMware WS 17.x
+	// Only listing values still seen (and used) on VMware WS 17.x
 	enum gui_setting {
 		POINTER_GRAB_UNGRAB	= 0x0003,	// Grab (0x1)/Ungrab(0x2) are combined on newer versions.
 										// VMware-wide preference.
 		CLIP_BOARD_SHARING	= 0x0010,	// per-VM setting.
-		UNKOWN_SETTING_1	= 0x0200,
 		TIME_SYNC			= 0x0400,	// per-VM setting. Only one still used on open_vmware_tools code.
-		UNKOWN_SETTING_2	= 0x0800,
 	};
 
 	status_t	EnableMouseSharing();


### PR DESCRIPTION
According to open_vm_tools, the unknown values could be defined as:

- "AUTO_RAISE_DISABLED = 0x0200". The value is seen, but with no matching option on the VMWare Workstation 17.x GUI.
- "DISABLE_CURSOR_OPTS = 0x0800". Which seems to mean: "toolbox/addons should not show cursor options", but again, there's seemingly no matching option on VMware GUI.

So, just leave in the three actually used values.