### PR TITLE
vmware_fs: add a fsync stub. Fixes copying files via Tracker.

### DIFF
--- a/vmware_fs/kernel_interface.cpp
+++ b/vmware_fs/kernel_interface.cpp
@@ -79,7 +79,7 @@ fs_vnode_ops vnode_ops = {
 	NULL,						//vmwfs_set_flags
 	NULL,						//vmwfs_select
 	NULL,						//vmwfs_deselect
-	NULL,						//vmwfs_fsync
+	&vmwfs_fsync,
 
 	NULL,						//vmwfs_read_symlink
 	NULL,						//vmwfs_create_symlink
@@ -91,7 +91,7 @@ fs_vnode_ops vnode_ops = {
 	&vmwfs_access,
 	&vmwfs_read_stat,
 	&vmwfs_write_stat,
-	NULL,
+	NULL,						// preallocate
 
 	/* file operations */
 	&vmwfs_create,

--- a/vmware_fs/vnode_operations.cpp
+++ b/vmware_fs/vnode_operations.cpp
@@ -268,3 +268,10 @@ vmwfs_write_stat(fs_volume* volume, fs_vnode* vnode, const struct stat* stat, ui
 
 	return ret;
 }
+
+
+status_t
+vmwfs_fsync(fs_volume* _volume, fs_vnode* _node, bool dataOnly)
+{
+	return B_OK;
+}

--- a/vmware_fs/vnode_operations.h
+++ b/vmware_fs/vnode_operations.h
@@ -14,4 +14,6 @@ status_t	vmwfs_access(fs_volume* volume, fs_vnode* vnode, int mode);
 status_t	vmwfs_read_stat(fs_volume* volume, fs_vnode* vnode, struct stat* stat);
 status_t	vmwfs_write_stat(fs_volume* volume, fs_vnode* vnode, const struct stat* stat, uint32 statMask);
 
+status_t	vmwfs_fsync(fs_volume* _volume, fs_vnode* _node, bool dataOnly);
+
 #endif


### PR DESCRIPTION
Besides the failed assert, this was the major issue on #64.