### PR TITLE
vmware_fs: code and style cleanups. No functional change intended.

### DIFF
--- a/vmware_fs/VMWNode.h
+++ b/vmware_fs/VMWNode.h
@@ -2,38 +2,39 @@
 #define VMW_NODE_H
 
 
-
 #include <List.h>
 #include <String.h>
 
+
 class VMWNode;
+
 
 typedef struct vmw_list_item {
 	VMWNode* node;
 	vmw_list_item* next;
-
 } vmw_list_item;
 
-class VMWNode {
-	static ino_t	current_inode;
 
+class VMWNode {
 public:
-					VMWNode(const char* _name, VMWNode* _parent);
+					VMWNode(const char* name, VMWNode* parent);
 	virtual			~VMWNode();
 
-	ssize_t			CopyPathTo(char* buffer, size_t buffer_length, const char* to_append = NULL);
+	ssize_t			CopyPathTo(char* buffer, size_t bufferLength, const char* toAppend = NULL);
 	void			DeleteChildIfExists(const char* name);
 	VMWNode*		GetChild(const char* name);
 	VMWNode*		GetChild(ino_t inode);
-	ino_t			GetInode() const { return inode; }
-	const char*		GetName() const { return name; }
+	ino_t			GetInode() const { return fInode; }
+	const char*		GetName() const { return fName; }
 
 private:
-	char*			name;
-	size_t			name_length;
-	VMWNode* 		parent;
-	ino_t			inode;
-	vmw_list_item*	children;
+	static ino_t	sCurrentInode;
+
+	vmw_list_item*	fChildren;
+	ino_t			fInode;
+	char*			fName;
+	size_t			fNameLength;
+	VMWNode* 		fParent;
 };
 
 #endif

--- a/vmware_fs/VMWSharedFolders.cpp
+++ b/vmware_fs/VMWSharedFolders.cpp
@@ -1,18 +1,16 @@
 /*
-	Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
-	All rights reserved. Distributed under the terms of the MIT License.
-*/
+ * Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
 
 #include "VMWSharedFolders.h"
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-
-#define ASSERT(x) if (!(x)) panic("ASSERT FAILED : " #x);
 
 #include <KernelExport.h>
+
+
+#define ASSERT(x) if (!(x)) panic("ASSERT FAILED : " #x);
 
 enum {
 	VMW_CMD_OPEN_FILE = 0,
@@ -30,57 +28,58 @@ enum {
 	VMW_CMD_MOVE_FILE
 };
 
-#define SET_8(offset, val) *(uint8*)(rpc_buffer + offset) = (uint8)val; offset += 1
-#define SET_32(offset, val) *(uint32*)(rpc_buffer + offset) = (uint32)val; offset += 4
-#define SET_64(offset, val) *(uint64*)(rpc_buffer + offset) = (uint64)val; offset += 8
+#define SET_8(offset, val) *(uint8*)(fRPCBuffer + offset) = (uint8)val; offset += 1
+#define SET_32(offset, val) *(uint32*)(fRPCBuffer + offset) = (uint32)val; offset += 4
+#define SET_64(offset, val) *(uint64*)(fRPCBuffer + offset) = (uint64)val; offset += 8
 
 #define SIZE_8 1
 #define SIZE_32 4
 #define SIZE_64 8
 #define SIZE_START 6
 
-VMWSharedFolders::VMWSharedFolders(size_t max_io_size)
+
+VMWSharedFolders::VMWSharedFolders(size_t maxIOSize)
 {
-	if (!backdoor.InVMware()) {
-		init_check = B_UNSUPPORTED;
+	if (!fBackdoor.InVMware()) {
+		fInitCheck = B_UNSUPPORTED;
 		return;
 	}
 
-	init_check = backdoor.OpenRPCChannel();
-
-	if (init_check != B_OK)
+	fInitCheck = fBackdoor.OpenRPCChannel();
+	if (fInitCheck != B_OK)
 		return;
 
-	init_check = backdoor.SendMessage("f ", true);
-
-	if (init_check != B_OK)
+	fInitCheck = fBackdoor.SendMessage("f ", true);
+	if (fInitCheck != B_OK)
 		return;
 
-	// max_io_size indicates the max buffer size used with ReadFile and WriteFile.
+	// maxIOSize indicates the max buffer size used with ReadFile and WriteFile.
 	// We need additional room on the send/receive buffer for the command header.
-	rpc_buffer_size = max_io_size + SIZE_START + SIZE_32 + SIZE_32 + SIZE_8 + SIZE_64 + SIZE_32;
-	rpc_buffer = (char*)malloc(rpc_buffer_size);
-	if (rpc_buffer == NULL) {
-		init_check = B_NO_MEMORY;
+	fRPCBufferSize = maxIOSize + SIZE_START + SIZE_32 + SIZE_32 + SIZE_8 + SIZE_64 + SIZE_32;
+	fRPCBuffer = (char*)malloc(fRPCBufferSize);
+	if (fRPCBuffer == NULL) {
+		fInitCheck = B_NO_MEMORY;
 		return;
 	}
-	
+
 	fLock = create_sem(1, "vmwfs_lock");
 	if (fLock < B_OK) {
-		free(rpc_buffer);
-		init_check = fLock;
+		free(fRPCBuffer);
+		fInitCheck = fLock;
 	}
 }
+
 
 VMWSharedFolders::~VMWSharedFolders()
 {
 	delete_sem(fLock);
-	free(rpc_buffer);
-	backdoor.CloseRPCChannel();
+	free(fRPCBuffer);
+	fBackdoor.CloseRPCChannel();
 }
 
+
 status_t
-VMWSharedFolders::OpenFile(const char* path, int open_mode, file_handle* handle)
+VMWSharedFolders::OpenFile(const char* path, int openMode, file_handle* handle)
 {
 	// Command string :
 	// 0) Magic value (6 bytes)
@@ -91,10 +90,10 @@ VMWSharedFolders::OpenFile(const char* path, int open_mode, file_handle* handle)
 	// 5) The path length, with ending null (32-bits)
 	// 6) The path itself (with / path delimiters replaced by null characters)
 
-	const size_t path_length = strlen(path);
-	size_t length = SIZE_START + SIZE_32 + SIZE_32 + SIZE_32 + SIZE_8 + SIZE_32 + path_length + 1;
+	const size_t pathLength = strlen(path);
+	size_t length = SIZE_START + SIZE_32 + SIZE_32 + SIZE_32 + SIZE_8 + SIZE_32 + pathLength + 1;
 
-	if (length > rpc_buffer_size)
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -102,32 +101,31 @@ VMWSharedFolders::OpenFile(const char* path, int open_mode, file_handle* handle)
 
 	size_t pos = StartCommand();
 	SET_32(pos, VMW_CMD_OPEN_FILE);
-	SET_32(pos, open_mode & 3);
+	SET_32(pos, openMode & 3);
 
-	uint32 vmw_openmode;
-	if ((open_mode & O_TRUNC) == O_TRUNC) {
-		vmw_openmode = 0x04;
-	} else if ((open_mode & O_CREAT) == O_CREAT) {
-		if ((open_mode & O_EXCL) == O_EXCL)
-			vmw_openmode = 0x03;
+	uint32 vmwOpenMode;
+	if ((openMode & O_TRUNC) == O_TRUNC)
+		vmwOpenMode = 0x04;
+	else if ((openMode & O_CREAT) == O_CREAT)
+		if ((openMode & O_EXCL) == O_EXCL)
+			vmwOpenMode = 0x03;
 		else
-			vmw_openmode = 0x02;
-	} else {
-		vmw_openmode = 0;
-	}
+			vmwOpenMode = 0x02;
+	else
+		vmwOpenMode = 0;
 
-	SET_32(pos, vmw_openmode);
+	SET_32(pos, vmwOpenMode);
 	SET_8(pos, 0x06);
-	SET_32(pos, path_length);
+	SET_32(pos, pathLength);
 	CopyPath(path, &pos);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length != 14) {
@@ -135,15 +133,16 @@ VMWSharedFolders::OpenFile(const char* path, int open_mode, file_handle* handle)
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
-	*handle = *(uint32*)(rpc_buffer + 10);
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
+	*handle = *(uint32*)(fRPCBuffer + 10);
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
 
+
 status_t
-VMWSharedFolders::ReadFile(file_handle handle, uint64 offset, void* read_buffer, uint32* read_length)
+VMWSharedFolders::ReadFile(file_handle handle, uint64 offset, void* readBuffer, uint32* readLength)
 {
 	// Command string :
 	// 0) Magic value (6 bytes, in BuildCommand)
@@ -154,8 +153,8 @@ VMWSharedFolders::ReadFile(file_handle handle, uint64 offset, void* read_buffer,
 
 	size_t length = SIZE_START + SIZE_32 + SIZE_32 + SIZE_64 + SIZE_32;
 
-	ASSERT(*read_length + length <= rpc_buffer_size);
-	if (*read_length + length > rpc_buffer_size)
+	ASSERT(*readLength + length <= fRPCBufferSize);
+	if (*readLength + length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -165,16 +164,16 @@ VMWSharedFolders::ReadFile(file_handle handle, uint64 offset, void* read_buffer,
 	SET_32(pos, VMW_CMD_READ_FILE);
 	SET_32(pos, handle);
 	SET_64(pos, offset);
-	uint32 max_length = *read_length;
-	SET_32(pos, *read_length);
+	uint32 maxLength = *readLength;
+	SET_32(pos, *readLength);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length < 14) {
@@ -182,32 +181,34 @@ VMWSharedFolders::ReadFile(file_handle handle, uint64 offset, void* read_buffer,
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
-	uint32 returned_length = *(uint32*)(rpc_buffer + 10);
-	if (returned_length > max_length) {
+	uint32 returnedLength = *(uint32*)(fRPCBuffer + 10);
+	if (returnedLength > maxLength) {
 		release_sem(fLock);
 		return B_BUFFER_OVERFLOW;
 	}
 
-	*read_length = returned_length;
+	*readLength = returnedLength;
 
-	if (user_memcpy(read_buffer, rpc_buffer + 14, *read_length) != B_OK) {
+	if (user_memcpy(readBuffer, fRPCBuffer + 14, *readLength) != B_OK) {
 		release_sem(fLock);
 		return B_BAD_ADDRESS;
 	}
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
 
+
 status_t
-VMWSharedFolders::WriteFile(file_handle handle, uint64 offset, const void* write_buffer, uint32* write_length)
+VMWSharedFolders::WriteFile(file_handle handle, uint64 offset, const void* writeBuffer,
+	uint32* writeLength)
 {
 	// Command string :
 	// 0) Magic value (6 bytes, in BuildCommand)
@@ -218,10 +219,10 @@ VMWSharedFolders::WriteFile(file_handle handle, uint64 offset, const void* write
 	// 5) Length (32-bits)
 
 	// /!\ should be changed in the constructor, too
-	size_t length = SIZE_START + SIZE_32 + SIZE_32 + SIZE_8 + SIZE_64 + SIZE_32 + *write_length;
+	size_t length = SIZE_START + SIZE_32 + SIZE_32 + SIZE_8 + SIZE_64 + SIZE_32 + *writeLength;
 
-	ASSERT(length <= rpc_buffer_size);
-	if (length > rpc_buffer_size)
+	ASSERT(length <= fRPCBufferSize);
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -232,22 +233,22 @@ VMWSharedFolders::WriteFile(file_handle handle, uint64 offset, const void* write
 	SET_32(pos, handle);
 	SET_8(pos, 0);
 	SET_64(pos, offset);
-	SET_32(pos, *write_length);
+	SET_32(pos, *writeLength);
 
-	if (user_memcpy(rpc_buffer + pos, write_buffer, *write_length) != B_OK) {
+	if (user_memcpy(fRPCBuffer + pos, writeBuffer, *writeLength) != B_OK) {
 		release_sem(fLock);
 		return B_BAD_ADDRESS;
 	}
 
-	pos += *write_length;
+	pos += *writeLength;
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length != 14) {
@@ -255,12 +256,13 @@ VMWSharedFolders::WriteFile(file_handle handle, uint64 offset, const void* write
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
-	*write_length = *(uint32*)(rpc_buffer + 10);
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
+	*writeLength = *(uint32*)(fRPCBuffer + 10);
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
+
 
 status_t
 VMWSharedFolders::CloseFile(file_handle handle)
@@ -281,11 +283,12 @@ VMWSharedFolders::CloseFile(file_handle handle)
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
+
 
 status_t
 VMWSharedFolders::OpenDir(const char* path, folder_handle* handle)
@@ -296,10 +299,10 @@ VMWSharedFolders::OpenDir(const char* path, folder_handle* handle)
 	// 2) Path length (32-bits)
 	// 3) The path itself (with / path delimiters replaced by null characters)
 
-	const size_t path_length = strlen(path);
-	size_t length = SIZE_START + SIZE_32 + SIZE_32 + path_length + 1;
+	const size_t pathLength = strlen(path);
+	size_t length = SIZE_START + SIZE_32 + SIZE_32 + pathLength + 1;
 
-	if (length > rpc_buffer_size)
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -307,16 +310,16 @@ VMWSharedFolders::OpenDir(const char* path, folder_handle* handle)
 
 	size_t pos = StartCommand();
 	SET_32(pos, VMW_CMD_OPEN_DIR);
-	SET_32(pos, path_length);
+	SET_32(pos, pathLength);
 	CopyPath(path, &pos);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length != 14) {
@@ -324,15 +327,16 @@ VMWSharedFolders::OpenDir(const char* path, folder_handle* handle)
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
-	*handle = *(uint32*)(rpc_buffer + 10);
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
+	*handle = *(uint32*)(fRPCBuffer + 10);
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
 
+
 status_t
-VMWSharedFolders::ReadDir(folder_handle handle, uint32 index, char* name, size_t max_length)
+VMWSharedFolders::ReadDir(folder_handle handle, uint32 index, char* name, size_t maxLength)
 {
 	// Command string :
 	// 0) Magic value (6 bytes, in BuildCommand)
@@ -352,11 +356,11 @@ VMWSharedFolders::ReadDir(folder_handle handle, uint32 index, char* name, size_t
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length < 59) {
@@ -364,23 +368,24 @@ VMWSharedFolders::ReadDir(folder_handle handle, uint32 index, char* name, size_t
 		return B_ERROR;
 	}
 
-	size_t name_length = *(uint32*)(rpc_buffer + 55);
-	if (name_length == 0) {
+	size_t nameLength = *(uint32*)(fRPCBuffer + 55);
+	if (nameLength == 0) {
 		release_sem(fLock);
 		return B_ENTRY_NOT_FOUND;
 	}
 
-	if (name_length > max_length - 1) {
+	if (nameLength > maxLength - 1) {
 		release_sem(fLock);
 		return B_BUFFER_OVERFLOW;
 	}
 
-	strncpy(name, rpc_buffer + 59, max_length - 1);
-	name[name_length] = '\0';
+	strncpy(name, fRPCBuffer + 59, maxLength - 1);
+	name[nameLength] = '\0';
 
 	release_sem(fLock);
 	return B_OK;
 }
+
 
 status_t
 VMWSharedFolders::CloseDir(folder_handle handle)
@@ -401,13 +406,14 @@ VMWSharedFolders::CloseDir(folder_handle handle)
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 	release_sem(fLock);
-	return ret;
+	return status;
 }
 
+
 status_t
-VMWSharedFolders::GetAttributes(const char* path, vmw_attributes* attributes, bool* is_dir)
+VMWSharedFolders::GetAttributes(const char* path, vmw_attributes* attributes, bool* isDir)
 {
 	// Command string :
 	// 0) Magic value (6 bytes, in BuildCommand)
@@ -415,10 +421,10 @@ VMWSharedFolders::GetAttributes(const char* path, vmw_attributes* attributes, bo
 	// 2) Path length (32-bits)
 	// 3) The path itself (with / path delimiters replaced by null characters)
 
-	const size_t path_length = strlen(path);
-	size_t length = SIZE_START + SIZE_32 + SIZE_32 + path_length + 1;
+	const size_t pathLength = strlen(path);
+	size_t length = SIZE_START + SIZE_32 + SIZE_32 + pathLength + 1;
 
-	if (length > rpc_buffer_size)
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -426,16 +432,16 @@ VMWSharedFolders::GetAttributes(const char* path, vmw_attributes* attributes, bo
 
 	size_t pos = StartCommand();
 	SET_32(pos, VMW_CMD_GET_ATTR);
-	SET_32(pos, path_length);
+	SET_32(pos, pathLength);
 	CopyPath(path, &pos);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length == 10) {
@@ -448,22 +454,23 @@ VMWSharedFolders::GetAttributes(const char* path, vmw_attributes* attributes, bo
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
-	if (is_dir != NULL)
-		*is_dir = (*(uint32*)(rpc_buffer + 10) == 0 ? false : true);
+	if (isDir != NULL)
+		*isDir = (*(uint32*)(fRPCBuffer + 10) == 0 ? false : true);
 
 	if (attributes != NULL)
-		memcpy(attributes, rpc_buffer + 14, sizeof(vmw_attributes));
+		memcpy(attributes, fRPCBuffer + 14, sizeof(vmw_attributes));
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
+
 
 status_t
 VMWSharedFolders::SetAttributes(const char* path, const vmw_attributes* attributes, uint32 mask)
@@ -477,10 +484,11 @@ VMWSharedFolders::SetAttributes(const char* path, const vmw_attributes* attribut
 	// 5) Path length (32-bits)
 	// 6) The path itself (with / path delimiters replaced by null characters)
 
-	const size_t path_length = strlen(path);
-	size_t length = SIZE_START + SIZE_32 + SIZE_32 + SIZE_8 + sizeof(vmw_attributes) + SIZE_32 + path_length + 1;
+	const size_t pathLength = strlen(path);
+	size_t length = SIZE_START + SIZE_32 + SIZE_32 + SIZE_8 + sizeof(vmw_attributes) + SIZE_32
+		+ pathLength + 1;
 
-	if (length > rpc_buffer_size)
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -490,18 +498,18 @@ VMWSharedFolders::SetAttributes(const char* path, const vmw_attributes* attribut
 	SET_32(pos, VMW_CMD_SET_ATTR);
 	SET_32(pos, mask);
 	SET_8(pos, 0);
-	memcpy(rpc_buffer + pos, attributes, sizeof(vmw_attributes));
+	memcpy(fRPCBuffer + pos, attributes, sizeof(vmw_attributes));
 	pos += sizeof(vmw_attributes);
-	SET_32(pos, path_length);
+	SET_32(pos, pathLength);
 	CopyPath(path, &pos);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length != 10) {
@@ -509,11 +517,12 @@ VMWSharedFolders::SetAttributes(const char* path, const vmw_attributes* attribut
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
+
 
 status_t
 VMWSharedFolders::CreateDir(const char* path, uint8 mode)
@@ -525,10 +534,10 @@ VMWSharedFolders::CreateDir(const char* path, uint8 mode)
 	// 3) Path length (32-bits)
 	// 4) The path itself (with / path delimiters replaced by null characters)
 
-	const size_t path_length = strlen(path);
-	size_t length = SIZE_START + SIZE_32 + SIZE_8 + SIZE_32 + path_length + 1;
+	const size_t pathLength = strlen(path);
+	size_t length = SIZE_START + SIZE_32 + SIZE_8 + SIZE_32 + pathLength + 1;
 
-	if (length > rpc_buffer_size)
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -539,16 +548,16 @@ VMWSharedFolders::CreateDir(const char* path, uint8 mode)
 	SET_32(pos, 0);
 	pos -= SIZE_32;
 	SET_8(pos, mode);
-	SET_32(pos, path_length);
+	SET_32(pos, pathLength);
 	CopyPath(path, &pos);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length != 10) {
@@ -556,14 +565,15 @@ VMWSharedFolders::CreateDir(const char* path, uint8 mode)
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
 
+
 status_t
-VMWSharedFolders::Delete(const char* path, bool is_dir)
+VMWSharedFolders::Delete(const char* path, bool isDir)
 {
 	// Command string :
 	// 0) Magic value (6 bytes, in BuildCommand)
@@ -571,27 +581,27 @@ VMWSharedFolders::Delete(const char* path, bool is_dir)
 	// 2) Path length (32-bits)
 	// 3) The path itself (with / path delimiters replaced by null characters)
 
-	const size_t path_length = strlen(path);
-	size_t length = SIZE_START + SIZE_32 + SIZE_32 + path_length + 1;
+	const size_t pathLength = strlen(path);
+	size_t length = SIZE_START + SIZE_32 + SIZE_32 + pathLength + 1;
 
-	if (length > rpc_buffer_size)
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
 		return B_ERROR;
 
 	size_t pos = StartCommand();
-	SET_32(pos, (is_dir ? VMW_CMD_DEL_DIR : VMW_CMD_DEL_FILE));
-	SET_32(pos, path_length);
+	SET_32(pos, isDir ? VMW_CMD_DEL_DIR : VMW_CMD_DEL_FILE);
+	SET_32(pos, pathLength);
 	CopyPath(path, &pos);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length != 10) {
@@ -599,11 +609,12 @@ VMWSharedFolders::Delete(const char* path, bool is_dir)
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
 
 	release_sem(fLock);
-	return ret;
+	return status;
 }
+
 
 status_t
 VMWSharedFolders::DeleteFile(const char* path)
@@ -611,14 +622,16 @@ VMWSharedFolders::DeleteFile(const char* path)
 	return Delete(path, false);
 }
 
+
 status_t
 VMWSharedFolders::DeleteDir(const char* path)
 {
 	return Delete(path, true);
 }
 
+
 status_t
-VMWSharedFolders::Move(const char* path_orig, const char* path_dest)
+VMWSharedFolders::Move(const char* pathOrig, const char* pathDest)
 {
 	// Command string :
 	// 0) Magic value (6 bytes, in BuildCommand)
@@ -629,12 +642,12 @@ VMWSharedFolders::Move(const char* path_orig, const char* path_dest)
 	// 5) The path itself (with / path delimiters replaced by null characters)
 
 
-	const size_t path_orig_length = strlen(path_orig);
-	const size_t path_dest_length = strlen(path_dest);
-	size_t length = SIZE_START + SIZE_32 + SIZE_32 + path_orig_length + 1 \
-		+ SIZE_32 + path_dest_length + 1;
+	const size_t pathOrigLength = strlen(pathOrig);
+	const size_t pathDestLength = strlen(pathDest);
+	size_t length
+		= SIZE_START + SIZE_32 + SIZE_32 + pathOrigLength + 1 + SIZE_32 + pathDestLength + 1;
 
-	if (length > rpc_buffer_size)
+	if (length > fRPCBufferSize)
 		return B_BUFFER_OVERFLOW;
 
 	if (acquire_sem(fLock) != B_OK)
@@ -642,18 +655,18 @@ VMWSharedFolders::Move(const char* path_orig, const char* path_dest)
 
 	size_t pos = StartCommand();
 	SET_32(pos, VMW_CMD_MOVE_FILE);
-	SET_32(pos, path_orig_length);
-	CopyPath(path_orig, &pos);
-	SET_32(pos, path_dest_length);
-	CopyPath(path_dest, &pos);
+	SET_32(pos, pathOrigLength);
+	CopyPath(pathOrig, &pos);
+	SET_32(pos, pathDestLength);
+	CopyPath(pathDest, &pos);
 
 	ASSERT(pos == length);
 
-	status_t ret = backdoor.SendAndGet(rpc_buffer, &length, rpc_buffer_size);
+	status_t status = fBackdoor.SendAndGet(fRPCBuffer, &length, fRPCBufferSize);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		release_sem(fLock);
-		return ret;
+		return status;
 	}
 
 	if (length != 10) {
@@ -661,20 +674,22 @@ VMWSharedFolders::Move(const char* path_orig, const char* path_dest)
 		return B_ERROR;
 	}
 
-	ret = ConvertStatus(*(uint32*)(rpc_buffer + 6));
+	status = ConvertStatus(*(uint32*)(fRPCBuffer + 6));
 	release_sem(fLock);
-	return ret;
+	return status;
 }
+
 
 size_t
 VMWSharedFolders::StartCommand()
 {
-	const char start_bytes[] = { 'f', ' ', '\0', '\0', '\0', '\0' };
+	const char startBytes[] = { 'f', ' ', '\0', '\0', '\0', '\0' };
 
-	memcpy(rpc_buffer, start_bytes, sizeof(start_bytes));
+	memcpy(fRPCBuffer, startBytes, sizeof(startBytes));
 
-	return sizeof(start_bytes);
+	return sizeof(startBytes);
 }
+
 
 status_t
 VMWSharedFolders::ConvertStatus(int vmw_status)
@@ -692,14 +707,14 @@ VMWSharedFolders::ConvertStatus(int vmw_status)
 		default:
 			dprintf("ConvertStatus: unknown status %d.\n", vmw_status);
 			return B_ERROR;
-
 	}
 }
+
 
 void
 VMWSharedFolders::CopyPath(const char* path, size_t* pos)
 {
-	char* dest = rpc_buffer + *pos;
+	char* dest = fRPCBuffer + *pos;
 	while (*path != '\0') {
 		*dest = (*path == '/' ? '\0' : *path);
 		dest++;

--- a/vmware_fs/VMWSharedFolders.h
+++ b/vmware_fs/VMWSharedFolders.h
@@ -1,7 +1,7 @@
 /*
-	Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
-	All rights reserved. Distributed under the terms of the MIT License.
-*/
+ * Copyright 2009 Vincent Duvert, vincent.duvert@free.fr
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
 
 #ifndef VMW_SHARED_H
 #define VMW_SHARED_H
@@ -9,6 +9,7 @@
 #include <SupportDefs.h>
 
 #include "VMWCoreBackdoor.h"
+
 
 typedef uint32 file_handle;
 typedef uint32 folder_handle;
@@ -24,13 +25,14 @@ typedef struct vmw_attributes {
 	uint8	perms;
 } __attribute__((packed)) vmw_attributes;
 
+
 #define MSK_READ 0x04
 #define MSK_WRITE 0x02
 #define MSK_EXEC 0x01
 
-#define CAN_READ(x) (((x).perms & MSK_READ) == MSK_READ)
-#define CAN_WRITE(x) (((x).perms & MSK_WRITE) == MSK_WRITE)
-#define CAN_EXEC(x) (((x).perms & MSK_EXEC) == MSK_EXEC)
+#define CAN_READ(x)		(((x).perms & MSK_READ) == MSK_READ)
+#define CAN_WRITE(x)	(((x).perms & MSK_WRITE) == MSK_WRITE)
+#define CAN_EXEC(x)		(((x).perms & MSK_EXEC) == MSK_EXEC)
 
 #define VMW_SET_SIZE	0x01
 #define VMW_SET_CRTIME	0x02
@@ -39,37 +41,41 @@ typedef struct vmw_attributes {
 #define VMW_SET_CTIME	0x10
 #define VMW_SET_PERMS	0x20
 
+
 class VMWSharedFolders {
 public:
-					VMWSharedFolders(size_t max_io_size);
+					VMWSharedFolders(size_t maxIOSize);
 	virtual			~VMWSharedFolders();
 
-	status_t		InitCheck() const { return init_check; }
-	status_t		OpenFile(const char* path, int open_mode, file_handle* handle);
-	status_t		ReadFile(file_handle handle, uint64 offset, void* read_buffer, uint32* read_length);
-	status_t		WriteFile(file_handle handle, uint64 offset, const void* write_buffer, uint32* write_length);
+	status_t		InitCheck() const { return fInitCheck; }
+	status_t		OpenFile(const char* path, int openMode, file_handle* handle);
+	status_t		ReadFile(file_handle handle, uint64 offset, void* readBuffer,
+						uint32* readLength);
+	status_t		WriteFile(file_handle handle, uint64 offset, const void* writeBuffer,
+						uint32* writeLength);
 	status_t		CloseFile(file_handle handle);
 	status_t		OpenDir(const char* path, folder_handle* handle);
-	status_t		ReadDir(folder_handle handle, uint32 index, char* name, size_t max_length);
+	status_t		ReadDir(folder_handle handle, uint32 index, char* name, size_t maxLength);
 	status_t		CloseDir(folder_handle handle);
-	status_t		GetAttributes(const char* path, vmw_attributes* attributes = NULL, bool* is_dir = NULL);
+	status_t		GetAttributes(const char* path, vmw_attributes* attributes = NULL,
+						bool* isDir = NULL);
 	status_t		SetAttributes(const char* path, const vmw_attributes* attributes, uint32 mask);
 	status_t		CreateDir(const char* path, uint8 mode);
 	status_t		DeleteFile(const char* path);
 	status_t		DeleteDir(const char* path);
-	status_t		Move(const char* path_orig, const char* path_dest);
+	status_t		Move(const char* pathOrig, const char* pathDest);
 
 private:
-	status_t		Delete(const char* path, bool is_dir);
+	status_t		Delete(const char* path, bool isDir);
 	size_t			StartCommand();
 	status_t		ConvertStatus(int vmw_status);
 	void			CopyPath(const char* path, size_t* pos);
 
-	VMWCoreBackdoor	backdoor;
-	status_t		init_check;
-	char*			rpc_buffer;
-	size_t			rpc_buffer_size;
+	VMWCoreBackdoor	fBackdoor;
+	status_t		fInitCheck;
 	sem_id			fLock;
+	char*			fRPCBuffer;
+	size_t			fRPCBufferSize;
 };
 
 #endif

--- a/vmware_fs/dir_operations.cpp
+++ b/vmware_fs/dir_operations.cpp
@@ -1,66 +1,72 @@
 #include <dirent.h>
-#include <sys/stat.h>
-#include <stdlib.h>
+
+#include <KernelExport.h>
 
 #include "vmwfs.h"
 
+
 #define VMWFS_PERMS_MODE_SHIFT 6
+
 
 typedef struct {
 	file_handle handle;
 	uint32 index;
 } dir_cookie;
 
+
 status_t
-vmwfs_create_dir(fs_volume* volume, fs_vnode* parent, const char* name, int perms)
+vmwfs_create_dir(fs_volume* volume, fs_vnode* parent, const char* name, int permissions)
 {
 	VMWNode* node = (VMWNode*)parent->private_node;
 
-	char* path_buffer = (char*)malloc(B_PATH_NAME_LENGTH);
-	if (path_buffer == NULL)
+	char* pathBuffer = (char*)malloc(B_PATH_NAME_LENGTH);
+	if (pathBuffer == NULL)
 		return B_NO_MEMORY;
 
-	ssize_t length = node->CopyPathTo(path_buffer, B_PATH_NAME_LENGTH, name);
+	ssize_t length = node->CopyPathTo(pathBuffer, B_PATH_NAME_LENGTH, name);
 	if (length < 0) {
-		free(path_buffer);
+		free(pathBuffer);
 		return B_BUFFER_OVERFLOW;
 	}
 
-	// Haiku passes permissions as a 32-bit value, but the VMWare RPC v1 calls we use
-	// accept permissions mode as `uint8` (expecting only the user bits of the original permissions value)
-	uint8 vmwfs_perms_mode = (perms & S_IRWXU) >> VMWFS_PERMS_MODE_SHIFT;
+	// Haiku passes permissions as a 32-bit value, but the VMWare RPC v1 calls we use accepts
+	// permissions mode as `uint8` (expecting only the user bits of the original permissions
+	// value)
+	uint8 mode = (permissions & S_IRWXU) >> VMWFS_PERMS_MODE_SHIFT;
 
-	status_t ret = shared_folders->CreateDir(path_buffer, vmwfs_perms_mode);
-	free(path_buffer);
+	status_t status = gSharedFolders->CreateDir(pathBuffer, mode);
+	free(pathBuffer);
 
-	return ret;
+	return status;
 }
+
 
 status_t
 vmwfs_remove_dir(fs_volume* volume, fs_vnode* parent, const char* name)
 {
 	VMWNode* node = (VMWNode*)parent->private_node;
 
-	char* path_buffer = (char*)malloc(B_PATH_NAME_LENGTH);
-	if (path_buffer == NULL)
+	char* pathBuffer = (char*)malloc(B_PATH_NAME_LENGTH);
+	if (pathBuffer == NULL)
 		return B_NO_MEMORY;
 
-	ssize_t length = node->CopyPathTo(path_buffer, B_PATH_NAME_LENGTH, name);
+	ssize_t length = node->CopyPathTo(pathBuffer, B_PATH_NAME_LENGTH, name);
 	if (length < 0) {
-		free(path_buffer);
+		free(pathBuffer);
 		return B_BUFFER_OVERFLOW;
 	}
 
-	status_t ret = shared_folders->DeleteDir(path_buffer);
-	free(path_buffer);
+	status_t status = gSharedFolders->DeleteDir(pathBuffer);
+	free(pathBuffer);
 
-	if (ret != B_OK)
-		return ret;
+	if (status != B_OK)
+		return status;
 
 	node->DeleteChildIfExists(name);
 
 	return B_OK;
 }
+
 
 status_t
 vmwfs_open_dir(fs_volume* volume, fs_vnode* vnode, void** _cookie)
@@ -73,25 +79,25 @@ vmwfs_open_dir(fs_volume* volume, fs_vnode* vnode, void** _cookie)
 
 	cookie->index = 0;
 
-	char* path_buffer = (char*)malloc(B_PATH_NAME_LENGTH);
-	if (path_buffer == NULL) {
+	char* pathBuffer = (char*)malloc(B_PATH_NAME_LENGTH);
+	if (pathBuffer == NULL) {
 		free(cookie);
 		return B_NO_MEMORY;
 	}
 
-	ssize_t length = node->CopyPathTo(path_buffer, B_PATH_NAME_LENGTH);
+	ssize_t length = node->CopyPathTo(pathBuffer, B_PATH_NAME_LENGTH);
 	if (length < 0) {
 		free(cookie);
-		free(path_buffer);
+		free(pathBuffer);
 		return B_BUFFER_OVERFLOW;
 	}
 
-	status_t ret = shared_folders->OpenDir(path_buffer, &cookie->handle);
-	free(path_buffer);
+	status_t status = gSharedFolders->OpenDir(pathBuffer, &cookie->handle);
+	free(pathBuffer);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		free(cookie);
-		return ret;
+		return status;
 	}
 
 	*_cookie = cookie;
@@ -99,11 +105,13 @@ vmwfs_open_dir(fs_volume* volume, fs_vnode* vnode, void** _cookie)
 	return B_OK;
 }
 
+
 status_t
 vmwfs_close_dir(fs_volume* volume, fs_vnode* vnode, void* cookie)
 {
-	return shared_folders->CloseDir(((dir_cookie*)cookie)->handle);
+	return gSharedFolders->CloseDir(((dir_cookie*)cookie)->handle);
 }
+
 
 status_t
 vmwfs_free_dir_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie)
@@ -112,8 +120,10 @@ vmwfs_free_dir_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie)
 	return B_OK;
 }
 
+
 status_t
-vmwfs_read_dir(fs_volume* volume, fs_vnode* vnode, void* _cookie, struct dirent* buffer, size_t bufferSize, uint32* _num)
+vmwfs_read_dir(fs_volume* volume, fs_vnode* vnode, void* _cookie, struct dirent* buffer,
+	size_t bufferSize, uint32* _num)
 {
 	VMWNode* node = (VMWNode*)vnode->private_node;
 	dir_cookie* cookie = (dir_cookie*)_cookie;
@@ -122,27 +132,28 @@ vmwfs_read_dir(fs_volume* volume, fs_vnode* vnode, void* _cookie, struct dirent*
 	if (entry == NULL)
 		return B_NO_MEMORY;
 
-	status_t ret = shared_folders->ReadDir(cookie->handle, cookie->index, entry->d_name, bufferSize - offsetof(struct dirent, d_name));
+	status_t status = gSharedFolders->ReadDir(cookie->handle, cookie->index, entry->d_name,
+		bufferSize - offsetof(struct dirent, d_name));
 
-	if (ret == B_ENTRY_NOT_FOUND) {
+	if (status == B_ENTRY_NOT_FOUND) {
 		*_num = 0;
 		free(entry);
 		return B_OK;
 	}
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		free(entry);
-		return ret;
+		return status;
 	}
 
-	VMWNode* child_node = node->GetChild(entry->d_name);
-	if (child_node == NULL) {
+	VMWNode* childNode = node->GetChild(entry->d_name);
+	if (childNode == NULL) {
 		free(entry);
 		return B_NO_MEMORY;
 	}
 
-	entry->d_dev = device_id;
-	entry->d_ino = child_node->GetInode();
+	entry->d_dev = gDeviceId;
+	entry->d_ino = childNode->GetInode();
 	entry->d_reclen = static_cast<ushort>(sizeof(struct dirent) + strlen(entry->d_name));
 
 	if (user_memcpy(buffer, entry, entry->d_reclen) != B_OK) {
@@ -158,6 +169,7 @@ vmwfs_read_dir(fs_volume* volume, fs_vnode* vnode, void* _cookie, struct dirent*
 
 	return B_OK;
 }
+
 
 status_t
 vmwfs_rewind_dir(fs_volume* volume, fs_vnode* vnode, void* cookie)

--- a/vmware_fs/dir_operations.h
+++ b/vmware_fs/dir_operations.h
@@ -1,12 +1,13 @@
 #ifndef VMW_FS_DIR_OPERATIONS_H
 #define VMW_FS_DIR_OPERATIONS_H
 
-status_t	vmwfs_create_dir(fs_volume* volume, fs_vnode* parent, const char* name, int perms);
-status_t	vmwfs_remove_dir(fs_volume* volume, fs_vnode* parent, const char* name);
-status_t	vmwfs_open_dir(fs_volume* volume, fs_vnode* vnode, void** _cookie);
-status_t	vmwfs_close_dir(fs_volume* volume, fs_vnode* vnode, void* cookie);
-status_t	vmwfs_free_dir_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie);
-status_t	vmwfs_read_dir(fs_volume* volume, fs_vnode* vnode, void* cookie, struct dirent* buffer, size_t bufferSize, uint32* _num);
-status_t	vmwfs_rewind_dir(fs_volume* volume, fs_vnode* vnode, void* cookie);
+status_t vmwfs_create_dir(fs_volume* volume, fs_vnode* parent, const char* name, int permissions);
+status_t vmwfs_remove_dir(fs_volume* volume, fs_vnode* parent, const char* name);
+status_t vmwfs_open_dir(fs_volume* volume, fs_vnode* vnode, void** _cookie);
+status_t vmwfs_close_dir(fs_volume* volume, fs_vnode* vnode, void* cookie);
+status_t vmwfs_free_dir_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie);
+status_t vmwfs_read_dir(fs_volume* volume, fs_vnode* vnode, void* cookie, struct dirent* buffer,
+	size_t bufferSize, uint32* _num);
+status_t vmwfs_rewind_dir(fs_volume* volume, fs_vnode* vnode, void* cookie);
 
 #endif

--- a/vmware_fs/file_operations.cpp
+++ b/vmware_fs/file_operations.cpp
@@ -1,66 +1,66 @@
-#include <stdlib.h>
-
 #include "vmwfs.h"
 
-status_t
-vmwfs_create(fs_volume* volume, fs_vnode* dir, const char* name, int openMode, int perms, void** _cookie, ino_t* _newVnodeID)
-{
-	VMWNode* dir_node = (VMWNode*)dir->private_node;
 
-	char* path_buffer = (char*)malloc(B_PATH_NAME_LENGTH);
-	if (path_buffer == NULL)
+status_t
+vmwfs_create(fs_volume* volume, fs_vnode* dir, const char* name, int openMode, int /*permissions*/,
+	void** _cookie, ino_t* _newVnodeID)
+{
+	VMWNode* node = (VMWNode*)dir->private_node;
+
+	char* pathBuffer = (char*)malloc(B_PATH_NAME_LENGTH);
+	if (pathBuffer == NULL)
 		return B_NO_MEMORY;
 
-	ssize_t length = dir_node->CopyPathTo(path_buffer, B_PATH_NAME_LENGTH, name);
+	ssize_t length = node->CopyPathTo(pathBuffer, B_PATH_NAME_LENGTH, name);
 	if (length < 0) {
-		free(path_buffer);
+		free(pathBuffer);
 		return B_BUFFER_OVERFLOW;
 	}
 
 	file_handle* cookie = (file_handle*)malloc(sizeof(file_handle));
 	if (cookie == NULL) {
-		free(path_buffer);
+		free(pathBuffer);
 		return B_NO_MEMORY;
 	}
 
-	status_t ret = shared_folders->OpenFile(path_buffer, openMode | O_CREAT, cookie);
-	free(path_buffer);
+	status_t status = gSharedFolders->OpenFile(pathBuffer, openMode | O_CREAT, cookie);
+	free(pathBuffer);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		free(cookie);
-		return ret;
+		return status;
 	}
 
 	*_cookie = cookie;
 
-	VMWNode* new_node = dir_node->GetChild(name);
-	if (new_node == NULL)
+	VMWNode* newNode = node->GetChild(name);
+	if (newNode == NULL)
 		return B_NO_MEMORY;
 
-	*_newVnodeID = new_node->GetInode();
+	*_newVnodeID = newNode->GetInode();
 
-	return get_vnode(volume, new_node->GetInode(), NULL);
-
+	return get_vnode(volume, newNode->GetInode(), NULL);
 }
+
 
 status_t
 vmwfs_open(fs_volume* volume, fs_vnode* vnode, int openMode, void** _cookie)
 {
 	VMWNode* node = (VMWNode*)vnode->private_node;
 
-	char* path_buffer = (char*)malloc(B_PATH_NAME_LENGTH);
-	if (path_buffer == NULL)
+	char* pathBuffer = (char*)malloc(B_PATH_NAME_LENGTH);
+	if (pathBuffer == NULL)
 		return B_NO_MEMORY;
 
-	ssize_t length = node->CopyPathTo(path_buffer, B_PATH_NAME_LENGTH);
+	ssize_t length = node->CopyPathTo(pathBuffer, B_PATH_NAME_LENGTH);
 	if (length < 0) {
-		free(path_buffer);
+		free(pathBuffer);
 		return B_BUFFER_OVERFLOW;
 	}
 
 	file_handle* cookie = (file_handle*)malloc(sizeof(file_handle));
 	if (cookie == NULL) {
-		free(path_buffer);
+		free(pathBuffer);
 		return B_NO_MEMORY;
 	}
 
@@ -70,28 +70,30 @@ vmwfs_open(fs_volume* volume, fs_vnode* vnode, int openMode, void** _cookie)
 		// We allow opening the root node as a file because it allows the volume
 		// to be shown in Tracker.
 		*cookie = (file_handle)(-1);
-		free(path_buffer);
+		free(pathBuffer);
 		return B_OK;
 	}
 
-	status_t ret = shared_folders->OpenFile(path_buffer, openMode, cookie);
-	free(path_buffer);
+	status_t status = gSharedFolders->OpenFile(pathBuffer, openMode, cookie);
+	free(pathBuffer);
 
-	if (ret != B_OK) {
+	if (status != B_OK) {
 		free(cookie);
-		return ret;
+		return status;
 	}
 
 	return B_OK;
 }
+
 
 status_t
 vmwfs_close(fs_volume* volume, fs_vnode* vnode, void* cookie)
 {
 	if (*(file_handle*)cookie == (file_handle)(-1))
 		return B_OK;
-	return shared_folders->CloseFile(*(file_handle*)cookie);
+	return gSharedFolders->CloseFile(*(file_handle*)cookie);
 }
+
 
 status_t
 vmwfs_free_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie)
@@ -100,45 +102,52 @@ vmwfs_free_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie)
 	return B_OK;
 }
 
+
 status_t
-vmwfs_read(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos, void* buffer, size_t* length)
+vmwfs_read(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos, void* buffer,
+	size_t* length)
 {
 	if (pos < 0)
 		return B_BAD_VALUE;
 
-	status_t ret;
-	uint32 to_read;
+	status_t status;
+	uint32 toRead;
 	size_t read = 0;
 
 	do {
-		to_read = static_cast<uint32>((*length - read) < IO_SIZE ? *length - read : IO_SIZE);
-		ret = shared_folders->ReadFile(*(file_handle*)cookie, pos + read, (uint8*)buffer + read, &to_read);
-		
-		read += to_read;
-	} while(to_read != 0 && read < *length && ret == B_OK); // to_read == 0 means EOF
+		toRead = static_cast<uint32>((*length - read) < IO_SIZE ? *length - read : IO_SIZE);
+		status = gSharedFolders->ReadFile(*(file_handle*)cookie, pos + read, (uint8*)buffer + read,
+			&toRead);
+
+		read += toRead;
+	} while (toRead != 0 && read < *length && status == B_OK); // toRead == 0 means EOF
 
 	*length = read;
 
-	return ret;
+	return status;
 }
 
+
 status_t
-vmwfs_write(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos, const void* buffer, size_t* length)
+vmwfs_write(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos, const void* buffer,
+	size_t* length)
 {
 	if (pos < 0)
 		return B_BAD_VALUE;
 
 	size_t written = 0;
-	status_t ret = B_OK;
+	status_t status = B_OK;
 
-	while (written < *length && ret == B_OK) {
-		uint32 to_write = static_cast<uint32>((*length - written) < IO_SIZE ? *length - written : IO_SIZE);
-		
-		ret = shared_folders->WriteFile(*(file_handle*)cookie, pos + written, (const uint8*)buffer + written, &to_write);
-		written += to_write;
+	while (written < *length && status == B_OK) {
+		uint32 toWrite
+			= static_cast<uint32>((*length - written) < IO_SIZE ? *length - written : IO_SIZE);
+
+		status = gSharedFolders->WriteFile(*(file_handle*)cookie, pos + written,
+			(const uint8*)buffer + written, &toWrite);
+		written += toWrite;
 	}
 
 	*length = written;
 
-	return ret;
+	return status;
 }

--- a/vmware_fs/file_operations.h
+++ b/vmware_fs/file_operations.h
@@ -1,11 +1,14 @@
 #ifndef VMW_FS_FILE_OPERATIONS_H
 #define VMW_FS_FILE_OPERATIONS_H
 
-status_t	vmwfs_create(fs_volume* volume, fs_vnode* dir, const char* name, int openMode, int perms, void** _cookie, ino_t* _newVnodeID);
-status_t	vmwfs_open(fs_volume* volume, fs_vnode* vnode, int openMode, void** _cookie);
-status_t	vmwfs_close(fs_volume* volume, fs_vnode* vnode, void* cookie);
-status_t	vmwfs_free_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie);
-status_t	vmwfs_read(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos, void* buffer, size_t* length);
-status_t	vmwfs_write(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos, const void* buffer, size_t* length);
+status_t vmwfs_create(fs_volume* volume, fs_vnode* dir, const char* name, int openMode,
+	int /*permissions*/, void** _cookie, ino_t* _newVnodeID);
+status_t vmwfs_open(fs_volume* volume, fs_vnode* vnode, int openMode, void** _cookie);
+status_t vmwfs_close(fs_volume* volume, fs_vnode* vnode, void* cookie);
+status_t vmwfs_free_cookie(fs_volume* volume, fs_vnode* vnode, void* cookie);
+status_t vmwfs_read(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos, void* buffer,
+	size_t* length);
+status_t vmwfs_write(fs_volume* volume, fs_vnode* vnode, void* cookie, off_t pos,
+	const void* buffer, size_t* length);
 
 #endif

--- a/vmware_fs/kernel_interface.cpp
+++ b/vmware_fs/kernel_interface.cpp
@@ -5,7 +5,9 @@
 #include "vnode_operations.h"
 #include "volume_operations.h"
 
-VMWSharedFolders* shared_folders;
+
+VMWSharedFolders* gSharedFolders;
+
 
 status_t
 vmw_std_ops(int32 op, ...)
@@ -21,79 +23,81 @@ vmw_std_ops(int32 op, ...)
 	}
 }
 
-fs_volume_ops volume_ops = {
+
+fs_volume_ops gVolumeOps = {
 	&vmwfs_unmount,
 
 	&vmwfs_read_fs_info,
 	&vmwfs_write_fs_info,
-	NULL,						//vmwfs_sync
+	NULL,					// vmwfs_sync
 
 	&vmwfs_get_vnode,
 
-	/* index directory & index operations */
-	NULL,						//vmwfs_open_index_dir
-	NULL,						//vmwfs_close_index_dir
-	NULL,						//vmwfs_free_index_dir_cookie
-	NULL,						//vmwfs_read_index_dir
-	NULL,						//vmwfs_rewind_index_dir
+	// index directory & index operations
+	NULL,					// vmwfs_open_index_dir
+	NULL,					// vmwfs_close_index_dir
+	NULL,					// vmwfs_free_index_dir_cookie
+	NULL,					// vmwfs_read_index_dir
+	NULL,					// vmwfs_rewind_index_dir
 
-	NULL,						//vmwfs_create_index
-	NULL,						//vmwfs_remove_index
-	NULL,						//vmwfs_read_index_stat
+	NULL,					// vmwfs_create_index
+	NULL,					// vmwfs_remove_index
+	NULL,					// vmwfs_read_index_stat
 
-	/* query operations */
-	NULL,						//vmwfs_open_query
-	NULL,						//vmwfs_close_query
-	NULL,						//vmwfs_free_query_cookie
-	NULL,						//vmwfs_read_query
-	NULL,						//vmwfs_rewind_query
+	// query operations
+	NULL,					// vmwfs_open_query
+	NULL,					// vmwfs_close_query
+	NULL,					// vmwfs_free_query_cookie
+	NULL,					// vmwfs_read_query
+	NULL,					// vmwfs_rewind_query
 
-	/* support for FS layers */
-	NULL,						//vmwfs_all_layers_mounted
-	NULL,						//vmwfs_create_sub_vnode
-	NULL,						//vmwfs_delete_sub_vnode
+	// support for FS layers
+	NULL,					// vmwfs_all_layers_mounted
+	NULL,					// vmwfs_create_sub_vnode
+	NULL,					// vmwfs_delete_sub_vnode
 };
 
-fs_vnode_ops vnode_ops = {
-	/* vnode operations */
+
+fs_vnode_ops gVnodeOps = {
+	// vnode operations
 	&vmwfs_lookup,
-	NULL,						//vmwfs_get_vnode_name
+	NULL,					// vmwfs_get_vnode_name
 
 	&vmwfs_put_vnode,
 	&vmwfs_remove_vnode,
 
-	/* VM file access */
-	NULL,						//vmwfs_can_page
-	NULL,						//vmwfs_read_pages
-	NULL,						//vmwfs_write_pages
+	// VM file access
+	NULL,					// vmwfs_can_page
+	NULL,					// vmwfs_read_pages
+	NULL,					// vmwfs_write_pages
 
-	/* asynchronous I/O */
-	NULL,						//vmwfs_io
-	NULL,						//vmwfs_cancel_io
+	// asynchronous I/O
+	NULL,					// vmwfs_io
+	NULL,					// vmwfs_cancel_io
 
-	/* cache file access */
-	NULL,						//vmwfs_get_file_map
+	// cache file access
+	NULL,					// vmwfs_get_file_map
 
-	/* common operations */
-	NULL,						//vmwfs_ioctl
-	NULL,						//vmwfs_set_flags
-	NULL,						//vmwfs_select
-	NULL,						//vmwfs_deselect
+	// common operations
+	NULL,					// vmwfs_ioctl
+	NULL,					// vmwfs_set_flags
+	NULL,					// vmwfs_select
+	NULL,					// vmwfs_deselect
 	&vmwfs_fsync,
 
-	NULL,						//vmwfs_read_symlink
-	NULL,						//vmwfs_create_symlink
+	NULL,					// vmwfs_read_symlink
+	NULL,					// vmwfs_create_symlink
 
-	NULL,						//vmwfs_link
+	NULL,					// vmwfs_link
 	&vmwfs_unlink,
 	&vmwfs_rename,
 
 	&vmwfs_access,
 	&vmwfs_read_stat,
 	&vmwfs_write_stat,
-	NULL,						// preallocate
+	NULL,					// preallocate
 
-	/* file operations */
+	// file operations
 	&vmwfs_create,
 	&vmwfs_open,
 	&vmwfs_close,
@@ -101,7 +105,7 @@ fs_vnode_ops vnode_ops = {
 	&vmwfs_read,
 	&vmwfs_write,
 
-	/* directory operations */
+	// directory operations
 	&vmwfs_create_dir,
 	&vmwfs_remove_dir,
 	&vmwfs_open_dir,
@@ -110,30 +114,31 @@ fs_vnode_ops vnode_ops = {
 	&vmwfs_read_dir,
 	&vmwfs_rewind_dir,
 
-	/* attribute directory operations */
-	NULL,						//vmwfs_open_attr_dir
-	NULL,						//vmwfs_close_attr_dir
-	NULL,						//vmwfs_free_attr_dir_cookie
-	NULL,						//vmwfs_read_attr_dir
-	NULL,						//vmwfs_rewind_attr_dir
+	// attribute directory operations
+	NULL,					// vmwfs_open_attr_dir
+	NULL,					// vmwfs_close_attr_dir
+	NULL,					// vmwfs_free_attr_dir_cookie
+	NULL,					// vmwfs_read_attr_dir
+	NULL,					// vmwfs_rewind_attr_dir
 
-	/* attribute operations */
-	NULL,						//vmwfs_create_attr
-	NULL,						//vmwfs_open_attr
-	NULL,						//vmwfs_close_attr
-	NULL,						//vmwfs_free_attr_cookie
-	NULL,						//vmwfs_read_attr
-	NULL,						//vmwfs_write_attr
+	// attribute operations
+	NULL,					// vmwfs_create_attr
+	NULL,					// vmwfs_open_attr
+	NULL,					// vmwfs_close_attr
+	NULL,					// vmwfs_free_attr_cookie
+	NULL,					// vmwfs_read_attr
+	NULL,					// vmwfs_write_attr
 
-	NULL,						//vmwfs_read_attr_stat
-	NULL,						//vmwfs_write_attr_stat
-	NULL,						//vmwfs_rename_attr
-	NULL,						//vmwfs_remove_attr
+	NULL,					// vmwfs_read_attr_stat
+	NULL,					// vmwfs_write_attr_stat
+	NULL,					// vmwfs_rename_attr
+	NULL,					// vmwfs_remove_attr
 
-	/* support for node and FS layers */
-	NULL,						//vmwfs_create_special_node
-	NULL,						//vmwfs_get_super_vnode
+	// support for node and FS layers
+	NULL,					// vmwfs_create_special_node
+	NULL,					// vmwfs_get_super_vnode
 };
+
 
 static file_system_module_info vmw_file_system = {
 	{
@@ -142,20 +147,22 @@ static file_system_module_info vmw_file_system = {
 		vmw_std_ops,
 	},
 
-	"vmwfs",						// short_name
-	"VMware ShF",					// pretty_name
+	"vmwfs",					// short_name
+	"VMware Shared Folders",	// pretty_name
+
 	B_DISK_SYSTEM_SUPPORTS_WRITING,	// DDM flags
 
 	// scanning
-	NULL,						//vmwfs_identify_partition
-	NULL,						//vmwfs_scan_partition
-	NULL,						//vmwfs_free_identify_partition_cookie
-	NULL,						//free_partition_content_cookie
+	NULL,			// vmwfs_identify_partition
+	NULL,			// vmwfs_scan_partition
+	NULL,			// vmwfs_free_identify_partition_cookie
+	NULL,			// free_partition_content_cookie
 
 	&vmwfs_mount,
 };
 
-module_info *modules[] = {
-	(module_info *)&vmw_file_system,
+
+module_info* modules[] = {
+	(module_info*)&vmw_file_system,
 	NULL,
 };

--- a/vmware_fs/vmwfs.h
+++ b/vmware_fs/vmwfs.h
@@ -1,9 +1,9 @@
 #ifndef VMW_FS_KERNEL_INTERFACE_H
 #define VMW_FS_KERNEL_INTERFACE_H
 
-#include <SupportDefs.h>
-#include <KernelExport.h>
+#include <stdlib.h>
 
+#include <SupportDefs.h>
 #include <fs_interface.h>
 
 #include "VMWNode.h"
@@ -12,11 +12,8 @@
 #define FAKE_BLOCK_SIZE 512
 #define IO_SIZE 4096
 
-extern VMWSharedFolders* shared_folders;
+extern VMWSharedFolders* gSharedFolders;
 
-extern fs_volume_ops volume_ops;
-extern fs_vnode_ops vnode_ops;
-
-extern dev_t device_id;
+extern dev_t gDeviceId;
 
 #endif

--- a/vmware_fs/vnode_operations.h
+++ b/vmware_fs/vnode_operations.h
@@ -1,19 +1,21 @@
 #ifndef VMW_FS_VNODE_OPERATIONS_H
 #define VMW_FS_VNODE_OPERATIONS_H
 
-status_t	vmwfs_lookup(fs_volume* volume, fs_vnode* dir, const char* name, ino_t* _id);
-status_t	vmwfs_get_vnode_name(fs_volume* volume, fs_vnode* vnode, char* buffer, size_t bufferSize);
+status_t vmwfs_lookup(fs_volume* volume, fs_vnode* dir, const char* name, ino_t* _id);
+status_t vmwfs_get_vnode_name(fs_volume* volume, fs_vnode* vnode, char* buffer, size_t bufferSize);
 
-status_t	vmwfs_put_vnode(fs_volume* volume, fs_vnode* vnode, bool reenter);
-status_t	vmwfs_remove_vnode(fs_volume* volume, fs_vnode* vnode, bool reenter);
+status_t vmwfs_put_vnode(fs_volume* volume, fs_vnode* vnode, bool reenter);
+status_t vmwfs_remove_vnode(fs_volume* volume, fs_vnode* vnode, bool reenter);
 
-status_t	vmwfs_unlink(fs_volume* volume, fs_vnode* dir, const char* name);
-status_t	vmwfs_rename(fs_volume* volume, fs_vnode* fromDir, const char* fromName, fs_vnode* toDir, const char* toName);
+status_t vmwfs_unlink(fs_volume* volume, fs_vnode* dir, const char* name);
+status_t vmwfs_rename(fs_volume* volume, fs_vnode* fromDir, const char* fromName, fs_vnode* toDir,
+	const char* toName);
 
-status_t	vmwfs_access(fs_volume* volume, fs_vnode* vnode, int mode);
-status_t	vmwfs_read_stat(fs_volume* volume, fs_vnode* vnode, struct stat* stat);
-status_t	vmwfs_write_stat(fs_volume* volume, fs_vnode* vnode, const struct stat* stat, uint32 statMask);
+status_t vmwfs_access(fs_volume* volume, fs_vnode* vnode, int mode);
+status_t vmwfs_read_stat(fs_volume* volume, fs_vnode* vnode, struct stat* stat);
+status_t vmwfs_write_stat(fs_volume* volume, fs_vnode* vnode, const struct stat* stat,
+	uint32 statMask);
 
-status_t	vmwfs_fsync(fs_volume* _volume, fs_vnode* _node, bool dataOnly);
+status_t vmwfs_fsync(fs_volume* _volume, fs_vnode* _node, bool dataOnly);
 
 #endif

--- a/vmware_fs/volume_operations.cpp
+++ b/vmware_fs/volume_operations.cpp
@@ -1,64 +1,69 @@
-#include <stdlib.h>
-
 #include <fs_info.h>
 
 #include "vmwfs.h"
 
-VMWNode* root_node;
+extern fs_volume_ops gVolumeOps;
+extern fs_vnode_ops gVnodeOps;
 
-int32 mount_count = 0;
+VMWNode* gRootNode;
+int32 gMountCount = 0;
+dev_t gDeviceId;
 
-dev_t device_id;
 
 status_t
-vmwfs_mount(fs_volume *_vol, const char *device, uint32 flags, const char *args, ino_t *_rootID)
+vmwfs_mount(fs_volume* _vol, const char* device, uint32 flags, const char* args, ino_t* _rootID)
 {
 	if (device != NULL)
 		return B_BAD_VALUE;
 
-	if (atomic_add(&mount_count, 1))
+	if (atomic_add(&gMountCount, 1))
 		return B_UNSUPPORTED;
 
-	shared_folders = new VMWSharedFolders(IO_SIZE);
-	if (shared_folders == NULL || shared_folders->InitCheck() != B_OK) {
-		atomic_add(&mount_count, -1);
-		delete shared_folders;
-		return (shared_folders == NULL ? B_NO_MEMORY : shared_folders->InitCheck());
+	gSharedFolders = new VMWSharedFolders(IO_SIZE);
+	if (gSharedFolders == NULL || gSharedFolders->InitCheck() != B_OK) {
+		atomic_add(&gMountCount, -1);
+		delete gSharedFolders;
+		return gSharedFolders == NULL ? B_NO_MEMORY : gSharedFolders->InitCheck();
 	}
 
-	root_node = new VMWNode("", NULL);
+	gRootNode = new VMWNode("", NULL);
 
-	if (root_node == NULL) {
-		delete root_node;
-		atomic_add(&mount_count, -1);
+	if (gRootNode == NULL) {
+		delete gRootNode;
+		atomic_add(&gMountCount, -1);
 		return B_NO_MEMORY;
 	}
 
-	*_rootID = root_node->GetInode();
+	*_rootID = gRootNode->GetInode();
 
-	_vol->private_volume = root_node;
-	_vol->ops = &volume_ops;
-	device_id = _vol->id;
+	_vol->private_volume = gRootNode;
+	_vol->ops = &gVolumeOps;
+	gDeviceId = _vol->id;
 
-	status_t ret = publish_vnode(_vol, *_rootID, (void*)_vol->private_volume,
-			&vnode_ops, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR | S_IWGRP | S_IWOTH | S_IFDIR | S_IXUSR | S_IXGRP | S_IXOTH, 0);
-	if (ret != B_OK)
-		atomic_add(&mount_count, -1);
+	status_t status = publish_vnode(_vol, *_rootID, (void*)_vol->private_volume, &gVnodeOps,
+		S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR | S_IWGRP | S_IWOTH | S_IFDIR | S_IXUSR | S_IXGRP
+			| S_IXOTH,
+		0);
+	if (status != B_OK)
+		atomic_add(&gMountCount, -1);
 
-	return ret;
+	return status;
 }
+
 
 status_t
 vmwfs_unmount(fs_volume* volume)
 {
-	put_vnode(volume, root_node->GetInode());
-	delete root_node;
-	delete shared_folders;
+	put_vnode(volume, gRootNode->GetInode());
 
-	atomic_add(&mount_count, -1);
+	delete gRootNode;
+	delete gSharedFolders;
+
+	atomic_add(&gMountCount, -1);
 
 	return B_OK;
 }
+
 
 status_t
 vmwfs_read_fs_info(fs_volume* volume, struct fs_info* info)
@@ -72,26 +77,29 @@ vmwfs_read_fs_info(fs_volume* volume, struct fs_info* info)
 	info->free_nodes = 0;
 
 	strcpy(info->device_name, "");
-	strcpy(info->volume_name, "VMW Shared Folders");
+	strcpy(info->volume_name, "VMware Shared Folders");
 
 	return B_OK;
 }
+
 
 status_t
 vmwfs_write_fs_info(fs_volume* volume, const struct fs_info* info, uint32 mask)
 {
-	// TODO : Store volume name ?
+	// TODO : Store volume name?
 	return B_OK;
 }
 
+
 status_t
-vmwfs_get_vnode(fs_volume* volume, ino_t id, fs_vnode* vnode, int* _type, uint32* _flags, bool reenter)
+vmwfs_get_vnode(fs_volume* volume, ino_t id, fs_vnode* vnode, int* _type, uint32* _flags,
+	bool reenter)
 {
 	vnode->private_node = NULL;
-	vnode->ops = &vnode_ops;
+	vnode->ops = &gVnodeOps;
 	_flags = 0;
 
-	VMWNode* node = root_node->GetChild(id);
+	VMWNode* node = gRootNode->GetChild(id);
 
 	if (node == NULL)
 		return B_ENTRY_NOT_FOUND;
@@ -110,12 +118,12 @@ vmwfs_get_vnode(fs_volume* volume, ino_t id, fs_vnode* vnode, int* _type, uint32
 
 	vmw_attributes attributes;
 	bool is_dir;
-	status_t ret = shared_folders->GetAttributes(path_buffer, &attributes, &is_dir);
-	
+	status_t status = gSharedFolders->GetAttributes(path_buffer, &attributes, &is_dir);
+
 	free(path_buffer);
-	
-	if (ret != B_OK)
-		return ret;
+
+	if (status != B_OK)
+		return status;
 
 	*_type = 0;
 	*_type |= (CAN_READ(attributes) ? S_IRUSR | S_IRGRP | S_IROTH : 0);

--- a/vmware_fs/volume_operations.h
+++ b/vmware_fs/volume_operations.h
@@ -1,12 +1,14 @@
 #ifndef VMW_FS_VOL_OPERATIONS_H
 #define VMW_FS_VOL_OPERATIONS_H
 
-status_t	vmwfs_mount(fs_volume *_vol, const char *device, uint32 flags, const char *args, ino_t *_rootID);
-status_t	vmwfs_unmount(fs_volume* volume);
+status_t vmwfs_mount(fs_volume* _vol, const char* device, uint32 flags, const char* args,
+	ino_t* _rootID);
+status_t vmwfs_unmount(fs_volume* volume);
 
-status_t	vmwfs_read_fs_info(fs_volume* volume, struct fs_info* info);
-status_t	vmwfs_write_fs_info(fs_volume* volume, const struct fs_info* info, uint32 mask);
+status_t vmwfs_read_fs_info(fs_volume* volume, struct fs_info* info);
+status_t vmwfs_write_fs_info(fs_volume* volume, const struct fs_info* info, uint32 mask);
 
-status_t	vmwfs_get_vnode(fs_volume* volume, ino_t id, fs_vnode* vnode, int* _type, uint32* _flags, bool reenter);
+status_t vmwfs_get_vnode(fs_volume* volume, ino_t id, fs_vnode* vnode, int* _type, uint32* _flags,
+	bool reenter);
 
 #endif


### PR DESCRIPTION
* Selectively applied haiku-format to the .cpp files.
* Manually updated style to match Haiku Coding Guidelines.
* Removed unused includes.
* Used "fMemberName" naming style for class member variables.
* Used "snakeCase" for variables/parameters, and placed vars closer to their usage location.
* Other minor clean ups, here and there.