### PR TITLE
vmware_fs: add missing missing node monitoring notifications.

### DIFF
--- a/vmware_fs/VMWNode.h
+++ b/vmware_fs/VMWNode.h
@@ -26,6 +26,7 @@ public:
 	VMWNode*		GetChild(ino_t inode);
 	ino_t			GetInode() const { return fInode; }
 	const char*		GetName() const { return fName; }
+	VMWNode*		GetParent() const { return fParent; }
 
 private:
 	static ino_t	sCurrentInode;

--- a/vmware_fs/kernel_interface.cpp
+++ b/vmware_fs/kernel_interface.cpp
@@ -62,7 +62,6 @@ fs_vnode_ops gVnodeOps = {
 	// vnode operations
 	&vmwfs_lookup,
 	NULL,					// vmwfs_get_vnode_name
-
 	&vmwfs_put_vnode,
 	&vmwfs_remove_vnode,
 


### PR DESCRIPTION
This fixes the last remaining issue I was seeing in #64.

Now Tracker properly shows newly created/removed/renamed files and dirs, shows size changes while writting files, and update stats when they change.